### PR TITLE
server: do not panic if a client disconnects.

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -612,6 +612,7 @@ impl<'a, L: Loop> ServerLoop<'a, L> {
         for i in 0..self.server.players.len() {
             if self.server.players[i].pid == pid {
                 self.server.players.swap_remove(i);
+                break;
             }
         }
     }


### PR DESCRIPTION
If a non-last client disconnects, an item is removed from the
self.server.players, thus making self.server.players.
However, the 'for' loop will try to iterate based on the
initial length, causing an out of bound access.