### PR TITLE
render_map: Simplify the code

### DIFF
--- a/render_map/src/main.rs
+++ b/render_map/src/main.rs
@@ -125,7 +125,8 @@ struct Image {
 
 const TILE_NUM: u32 = 16;
 
-fn transform_image(tileset: Array2<Color>, tile_len: u32)
+/// Scales `tileset` to `tile_len` * TILE_NUM pixels, clears first (air) tile.
+fn normalize_tileset(tileset: Array2<Color>, tile_len: u32)
     -> Array2<Color>
 {
     let dim = tileset.dim();
@@ -316,7 +317,7 @@ fn process<E>(path: &Path, out_path: &Path, mut external: &mut E, config: &Confi
     }
 
     for image in images.values_mut() {
-        image.data = transform_image(mem::replace(&mut image.data, Array2::default((0, 0))), tile_len);
+        image.data = normalize_tileset(mem::replace(&mut image.data, Array2::default((0, 0))), tile_len);
     }
 
     let result_width = width.checked_mul(tile_len).unwrap();

--- a/render_map/src/main.rs
+++ b/render_map/src/main.rs
@@ -328,14 +328,13 @@ fn process<E>(path: &Path, out_path: &Path, mut external: &mut E, config: &Confi
         let image = &images[&l.image];
         let layer_max_y = cmp::min(l.tiles.dim().0.assert_u32(), max_y);
         let layer_max_x = cmp::min(l.tiles.dim().1.assert_u32(), max_x);
-        if layer_max_x <= min_x || layer_max_y <= min_y {
-            continue;
-        }
-        for y in 0..height {
-            for x in 0..width {
-                let layer_y = cmp::min(l.tiles.dim().0 - 1, (min_y + y).usize());
-                let layer_x = cmp::min(l.tiles.dim().1 - 1, (min_x + x).usize());
-                let tile = l.tiles[(layer_y, layer_x)];
+
+        for layer_y in min_y..layer_max_y {
+            for layer_x in min_x..layer_max_x {
+                let target_y = layer_y - min_y;
+                let target_x = layer_x - min_x;
+
+                let tile = l.tiles[(layer_y.usize(), layer_x.usize())];
 
                 let rotate = tile.flags & format::TILEFLAG_ROTATE != 0;
                 let vflip = tile.flags & format::TILEFLAG_VFLIP != 0;
@@ -350,7 +349,7 @@ fn process<E>(path: &Path, out_path: &Path, mut external: &mut E, config: &Confi
 
                 for iy in 0..tile_len {
                     for ix in 0..tile_len {
-                        let p_target = &mut result[((y * tile_len + iy).usize(), (x * tile_len + ix).usize())];
+                        let p_target = &mut result[((target_y * tile_len + iy).usize(), (target_x * tile_len + ix).usize())];
                         let (ty, tx) = transform_coordinates((iy, ix), rotate, vflip, hflip, tile_len);
                         let p_tile = image.data[((tile_y * tile_len + ty).usize(), (tile_x * tile_len + tx).usize())];
                         *p_target = p_target.overlay_with(p_tile.mask(l.color));


### PR DESCRIPTION
Splitting process() will probably provide more info in flamegraphs.

I've tested with (wasntme) and Back in Time 2 to confirm that the output hasn't changed (not a single byte). I didn't notice major changes in performance either.