### PR TITLE
doc: fix github flavored markdown table and right-align first two rows

### DIFF
--- a/doc/snapshot.md
+++ b/doc/snapshot.md
@@ -101,26 +101,26 @@ Pre-agreed item sizes
 
 This describes the 0.6 protocol of Teeworlds.
 
-`type_id` | `size` | name
-----------+--------+--------------
-       1  |    10  | obj_player_input
-       2  |     6  | obj_projectile
-       3  |     5  | obj_laser
-       4  |     4  | obj_pickup
-       5  |     3  | obj_flag
-       6  |     8  | obj_game_info
-       7  |     4  | obj_game_data
-       8  |    15  | obj_character_core
-       9  |    22  | obj_character
-      10  |     5  | obj_player_info
-      11  |    17  | obj_client_info
-      12  |     3  | obj_spectator_info
-      13  |     2  | event_common
-      14  |     2  | event_explosion
-      15  |     2  | event_spawn
-      16  |     2  | event_hammerhit
-      17  |     3  | event_death
-      18  |     3  | event_sound_global
-      19  |     3  | event_sound_world
-      20  |     3  | event_damage_indicator
+| `type_id` | `size` | name                   |
+| --------: | -----: | ---------------------- |
+|        1  |    10  | obj_player_input       |
+|        2  |     6  | obj_projectile         |
+|        3  |     5  | obj_laser              |
+|        4  |     4  | obj_pickup             |
+|        5  |     3  | obj_flag               |
+|        6  |     8  | obj_game_info          |
+|        7  |     4  | obj_game_data          |
+|        8  |    15  | obj_character_core     |
+|        9  |    22  | obj_character          |
+|       10  |     5  | obj_player_info        |
+|       11  |    17  | obj_client_info        |
+|       12  |     3  | obj_spectator_info     |
+|       13  |     2  | event_common           |
+|       14  |     2  | event_explosion        |
+|       15  |     2  | event_spawn            |
+|       16  |     2  | event_hammerhit        |
+|       17  |     3  | event_death            |
+|       18  |     3  | event_sound_global     |
+|       19  |     3  | event_sound_world      |
+|       20  |     3  | event_damage_indicator |
 


### PR DESCRIPTION
Leaving out the outer `|` didn't work, because all rows were detected as a code block (4 spaces indent)