### PR TITLE
snapshot: Remove `DeltaReader`

### DIFF
--- a/snapshot/src/lib.rs
+++ b/snapshot/src/lib.rs
@@ -15,7 +15,6 @@ pub use manager::Manager;
 pub use receiver::DeltaReceiver;
 pub use receiver::ReceivedDelta;
 pub use snap::Delta;
-pub use snap::DeltaReader;
 pub use snap::Snap;
 pub use storage::Storage;
 

--- a/snapshot/src/manager.rs
+++ b/snapshot/src/manager.rs
@@ -1,5 +1,4 @@
 use Delta;
-use DeltaReader;
 use DeltaReceiver;
 use ReceivedDelta;
 use Snap;
@@ -66,7 +65,6 @@ impl From<storage::Warning> for Warning {
 #[derive(Clone, Default)]
 struct ManagerInner {
     temp_delta: Delta,
-    reader: DeltaReader,
     storage: Storage,
 }
 
@@ -131,7 +129,7 @@ impl ManagerInner {
     {
         let crc = delta.data_and_crc.map(|d| d.1);
         if let Some((data, _)) = delta.data_and_crc {
-            self.reader.read(wrap(warn), &mut self.temp_delta, object_size, &mut Unpacker::new(data))?;
+            self.temp_delta.read(wrap(warn), object_size, &mut Unpacker::new(data))?;
         } else {
             self.temp_delta.clear();
         }

--- a/snapshot/tests/correctness.rs
+++ b/snapshot/tests/correctness.rs
@@ -9,7 +9,6 @@ use gamenet::snap_obj::obj_size;
 use packer::Unpacker;
 use packer::with_packer;
 use snapshot::snap::Delta;
-use snapshot::snap::DeltaReader;
 use snapshot::snap::Snap;
 use warn::Panic;
 
@@ -22,7 +21,6 @@ const SECOND_CRC: i32 = 0x5b96263b;
 #[test]
 fn simple() {
     let mut buf = Vec::with_capacity(4096);
-    let mut reader = DeltaReader::new();
     let mut delta = Delta::new();
     let mut prev = Snap::empty();
     let mut snap = Snap::default();
@@ -34,7 +32,7 @@ fn simple() {
         Ok(p.written())
     }).unwrap();
 
-    reader.read(&mut Panic, &mut delta, obj_size, &mut Unpacker::new(&buf)).unwrap();
+    delta.read(&mut Panic, obj_size, &mut Unpacker::new(&buf)).unwrap();
     snap.read_with_delta(&mut Panic, &prev, &delta).unwrap();
     println!("{:?}", snap);
     assert_eq!(snap.crc(), FIRST_CRC);
@@ -50,7 +48,7 @@ fn simple() {
         Ok(p.written())
     }).unwrap();
 
-    reader.read(&mut Panic, &mut delta, obj_size, &mut Unpacker::new(&buf)).unwrap();
+    delta.read(&mut Panic, obj_size, &mut Unpacker::new(&buf)).unwrap();
     snap.read_with_delta(&mut Panic, &prev, &delta).unwrap();
     println!("{:?}", snap);
     assert_eq!(snap.crc(), SECOND_CRC);


### PR DESCRIPTION
Removes an intermediate buffer and copy