### PR TITLE
doc: Fix chunk header vital mixup

### DIFF
--- a/doc/packet.md
+++ b/doc/packet.md
@@ -17,7 +17,7 @@ All sizes in bits.
 NOTE: `padding` must be zeroed, it's incorrectly used as part of the `ack`
 field while unpacking in the reference implementation.
 
-    chunk_header_vital:
+    chunk_header_nonvital:
         [ 1] flag_resend
         [ 1] flag_vital
         [ 6] <----------
@@ -27,7 +27,7 @@ field while unpacking in the reference implementation.
         FFss ssss  PPPP ssss
 
 
-    chunk_header_nonvital:
+    chunk_header_vital:
         [ 1] flag_resend
         [ 1] flag_vital
         [ 6] <----------

--- a/doc/packet7.md
+++ b/doc/packet7.md
@@ -34,7 +34,7 @@ not be set. `flag_control` implies `!flag_compression`.
 
 NOTE: In `packet7_header_connless`, `version` must be set to 1.
 
-    chunk7_header_vital:
+    chunk7_header_nonvital:
         [ 1] flag_resend
         [ 1] flag_vital
         [ 6] <----------
@@ -44,7 +44,7 @@ NOTE: In `packet7_header_connless`, `version` must be set to 1.
         FFss ssss  PPss ssss
 
 
-    chunk7_header_nonvital:
+    chunk7_header_vital:
         [ 1] flag_resend
         [ 1] flag_vital
         [ 6] <----------


### PR DESCRIPTION
The seq number is included if it is a vital chunk

https://github.com/teeworlds/teeworlds/blob/26d24ec061d44e6084b2d77a9b8a0a48e354eba6/src/engine/shared/network.cpp#L383-L407