### PR TITLE
Document empty packets

### DIFF
--- a/doc/quirks.md
+++ b/doc/quirks.md
@@ -8,3 +8,6 @@
 - The client wants to receive the last snapshot part last, otherwise the
   resulting delta is too long.
 - CCharacterCore has unused fields `m_HookDx`, `m_HookDy`
+- The packet payload can be empty. This happens when chunks from the peer are
+  lost, a resend of these is requested but no new chunks to the peer are queued
+  yet.


### PR DESCRIPTION
I was about to open a pr to change that. When I realized this is probably intentional design. When there is nothing to send but we still want to request a resend it is fine to just send the header without payload to inform the other side. Something to watch out for when reimplementing the protocol.

```diff
index d101e700..83a7966c 100644
--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -86,8 +86,7 @@ void CNetConnection::SignalResend()
 
 int CNetConnection::Flush()
 {
-       int NumChunks = m_Construct.m_NumChunks;
-       if(!NumChunks && !m_Construct.m_Flags)
+       if(!m_Construct.m_DataSize)
                return 0;
 
        // send of the packets
@@ -100,7 +99,7 @@ int CNetConnection::Flush()
 
        // clear construct so we can start building a new package
        mem_zero(&m_Construct, sizeof(m_Construct));
-       return NumChunks;
+       return m_Construct.m_NumChunks;
 }
 
 int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int Sequence)

```