### PR TITLE
common: Make `file_offset` dependency optional 

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 arrayvec = "0.5.2"
-file_offset = "0.1.0"
+file_offset = { version = "0.1.0", optional = true }
 serde = { version = "1.0.23", optional = true }
 
 [dev-dependencies]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate quickcheck;
 
 extern crate arrayvec;
+#[cfg(feature = "file_offset")]
 extern crate file_offset;
 #[cfg(feature = "serde")]
 extern crate serde;

--- a/datafile/Cargo.toml
+++ b/datafile/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["heinrich5991 <heinrich5991@gmail.com>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-common = { path = "../common/" }
+common = { path = "../common/", features = ["file_offset"] }
 hexdump = "0.1.1"
 itertools = ">=0.3.0,<0.5.0"
 log = "0.3.0"


### PR DESCRIPTION
Uses `file_offset::FileExt::read_offset`, which is only available for unix, windows.
This change allows building for WebAssembly, by removing the implementation conditionally.
Moved some `use`s for no warnings in the wasm build.