### PR TITLE
gamenet: Add fields to SvGameMsg

### DIFF
--- a/gamenet/generate/loader.py
+++ b/gamenet/generate/loader.py
@@ -145,12 +145,18 @@ def fix_network(network, version):
         ]
 
     TUNE_PARAMS = ("sv", "tune", "params")
+    GAME_MSG = ("sv", "game", "msg")
     EXTRA_PROJECTILE = ("sv", "extra", "projectile")
     IS_DDNET = ("cl", "is", "ddnet")
     IS_DDNET_LEGACY = ("cl", "is", "ddnet", "legacy")
     for i in range(len(network.Messages)):
         if network.Messages[i].name == TUNE_PARAMS:
             network.Messages[i] = NetMessage("SvTuneParams", [NetTuneParam(n) for n in TUNE_PARAM_NAMES[version]])
+        elif network.Messages[i].name == GAME_MSG:
+            network.Messages[i].values.append(NetIntRange("m_GameMsg", 'GAMEMSG_TEAM_SWAP', 'GAMEMSG_GAME_PAUSED'))
+            network.Messages[i].values.append(NetIntAny("para_i"))
+            network.Messages[i].values.append(NetIntAny("para_ii"))
+            network.Messages[i].values.append(NetIntAny("para_iii"))
         elif network.Messages[i].name == EXTRA_PROJECTILE:
             network.Messages[i].values.append(NetObjectMember("projectile", ("projectile",)))
         elif network.Messages[i].name in (IS_DDNET, IS_DDNET_LEGACY):

--- a/gamenet/generate/spec/teeworlds-0.7.5.json
+++ b/gamenet/generate/spec/teeworlds-0.7.5.json
@@ -458,7 +458,12 @@
 		{
 			"id": 21,
 			"name": ["sv", "game", "msg"],
-			"members": [],
+			"members": [
+				{"name": ["game", "msg"], "type": {"kind": "enum", "enum": ["gamemsg"]}},
+				{"name": ["para", "i"], "type": {"kind": "optional", "inner": {"kind": "int32"}}},
+				{"name": ["para", "ii"], "type": {"kind": "optional", "inner": {"kind": "int32"}}},
+				{"name": ["para", "iii"], "type": {"kind": "optional", "inner": {"kind": "int32"}}}
+			],
 			"attributes": []
 		},
 		{

--- a/gamenet/generate/spec/teeworlds-0.7.5.json
+++ b/gamenet/generate/spec/teeworlds-0.7.5.json
@@ -459,10 +459,10 @@
 			"id": 21,
 			"name": ["sv", "game", "msg"],
 			"members": [
-				{"name": ["game", "msg"], "type": {"kind": "enum", "enum": ["gamemsg"]}},
-				{"name": ["para", "i"], "type": {"kind": "optional", "inner": {"kind": "int32"}}},
-				{"name": ["para", "ii"], "type": {"kind": "optional", "inner": {"kind": "int32"}}},
-				{"name": ["para", "iii"], "type": {"kind": "optional", "inner": {"kind": "int32"}}}
+				{"name": ["game", "msg"], "type": {"kind": "int32", "min": 0, "max": 10}},
+				{"name": ["para", "i"], "type": {"kind": "int32"}},
+				{"name": ["para", "ii"], "type": {"kind": "int32"}},
+				{"name": ["para", "iii"], "type": {"kind": "int32"}}
 			],
 			"attributes": []
 		},

--- a/gamenet/teeworlds-0.7/src/msg/game.rs
+++ b/gamenet/teeworlds-0.7/src/msg/game.rs
@@ -698,7 +698,12 @@ pub struct SvClientDrop<'a> {
 }
 
 #[derive(Clone, Copy)]
-pub struct SvGameMsg;
+pub struct SvGameMsg {
+    pub game_msg: enums::Gamemsg,
+    pub para_i: Option<i32>,
+    pub para_ii: Option<i32>,
+    pub para_iii: Option<i32>,
+}
 
 #[derive(Clone, Copy)]
 pub struct DeClientEnter<'a> {
@@ -1486,17 +1491,33 @@ impl<'a> fmt::Debug for SvClientDrop<'a> {
 
 impl SvGameMsg {
     pub fn decode<W: Warn<Warning>>(warn: &mut W, _p: &mut Unpacker) -> Result<SvGameMsg, Error> {
-        let result = Ok(SvGameMsg);
+        let result = Ok(SvGameMsg {
+            game_msg: enums::Gamemsg::from_i32(_p.read_int(warn)?)?,
+            para_i: _p.read_int(warn).ok(),
+            para_ii: _p.read_int(warn).ok(),
+            para_iii: _p.read_int(warn).ok(),
+        });
         _p.finish(warn);
         result
     }
     pub fn encode<'d, 's>(&self, mut _p: Packer<'d, 's>) -> Result<&'d [u8], CapacityError> {
+        assert!(self.para_i.is_some());
+        assert!(self.para_ii.is_some());
+        assert!(self.para_iii.is_some());
+        _p.write_int(self.game_msg.to_i32())?;
+        _p.write_int(self.para_i.unwrap())?;
+        _p.write_int(self.para_ii.unwrap())?;
+        _p.write_int(self.para_iii.unwrap())?;
         Ok(_p.written())
     }
 }
 impl fmt::Debug for SvGameMsg {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("SvGameMsg")
+            .field("game_msg", &self.game_msg)
+            .field("para_i", &self.para_i.as_ref().map(|v| v))
+            .field("para_ii", &self.para_ii.as_ref().map(|v| v))
+            .field("para_iii", &self.para_iii.as_ref().map(|v| v))
             .finish()
     }
 }


### PR DESCRIPTION
Para I-III are not i32 at all times. Some of them might be the team enum. But that depends on the gamemsg field and I do not think the current code supports such logic. I would love to add some if statements to the generated rust code but it seems wrong. Not sure how complex the generation code would be if it would support if statements or field relations. Also might look ugly in the json. So I went with the raw i32 for now.

If you need a refresher on what this message does I fully documented it here https://chillerdragon.github.io/teeworlds-protocol/07/game_messages.html#NETMSGTYPE_SV_GAMEMSG

Here is how it looks in action used by the wireshark dissector.

Before:

![Screenshot from 2024-02-12 10-50-54](https://github.com/heinrich5991/libtw2/assets/20344300/b359d14d-a1f5-4649-99f2-e8f4dc6d0664)

After:

![Screenshot from 2024-02-12 10-50-11](https://github.com/heinrich5991/libtw2/assets/20344300/75734450-deae-4b65-956b-e61491d25125)
