### PR TITLE
[RFC] demo: Replace 'static with explicit lifetime 'a

### DIFF
--- a/demo/src/ddnet/reader.rs
+++ b/demo/src/ddnet/reader.rs
@@ -37,8 +37,8 @@ pub enum ReadError {
     ChunkOrder,
 }
 
-pub struct DemoReader<P: for<'a> Protocol<'a>> {
-    raw: reader::Reader,
+pub struct DemoReader<'a, P: for<'p> Protocol<'p>> {
+    raw: reader::Reader<'a>,
     delta: Delta,
     snap: Snap,
     old_snap: Snap,
@@ -84,10 +84,10 @@ pub enum Chunk<'a, P: Protocol<'a>> {
     Invalid,
 }
 
-impl<P: for<'a> Protocol<'a>> DemoReader<P> {
+impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
     pub fn new<R, W>(data: R, warn: &mut W) -> Result<Self, ReadError>
     where
-        R: io::Read + io::Seek + 'static,
+        R: io::Read + io::Seek + 'a,
         W: Warn<Warning>,
     {
         let reader = reader::Reader::new(data, wrap(warn))?;
@@ -146,7 +146,7 @@ impl<P: for<'a> Protocol<'a>> DemoReader<P> {
         }
     }
 
-    pub fn inner(&self) -> &reader::Reader {
+    pub fn inner(&'a self) -> &'a reader::Reader {
         &self.raw
     }
 }

--- a/demo/src/ddnet/writer.rs
+++ b/demo/src/ddnet/writer.rs
@@ -44,8 +44,8 @@ impl From<snap::BuilderError> for WriteError {
 /// DDNet demo writer.
 ///
 /// Automatically writes snapshot deltas.
-pub struct DemoWriter<P: for<'a> Protocol<'a>> {
-    inner: crate::Writer,
+pub struct DemoWriter<'a, P: for<'p> Protocol<'p>> {
+    inner: crate::Writer<'a>,
     // To verify the monotonic increase
     last_tick: i32,
     // Stores the last tick, in which a snapshot was written.
@@ -94,8 +94,8 @@ impl UuidIndex {
     }
 }
 
-impl<P: for<'a> Protocol<'a>> DemoWriter<P> {
-    pub fn new<T: io::Write + io::Seek + 'static>(
+impl<'a, P: for<'p> Protocol<'p>> DemoWriter<'a, P> {
+    pub fn new<T: io::Write + io::Seek + 'a>(
         file: T,
         net_version: &[u8],
         map_name: &[u8],
@@ -132,7 +132,7 @@ impl<P: for<'a> Protocol<'a>> DemoWriter<P> {
         })
     }
 
-    pub fn write_snap<'a, T: Iterator<Item = (&'a P::SnapObj, u16)>>(
+    pub fn write_snap<'b, T: Iterator<Item = (&'b P::SnapObj, u16)>>(
         &mut self,
         tick: i32,
         items: T,

--- a/demo/src/reader.rs
+++ b/demo/src/reader.rs
@@ -45,19 +45,19 @@ impl ReadError {
 trait SeekableRead: io::Read + io::Seek {}
 impl<T: io::Read + io::Seek> SeekableRead for T {}
 
-pub struct Reader {
-    data: Box<dyn SeekableRead>,
+pub struct Reader<'a> {
+    data: Box<dyn SeekableRead + 'a>,
     start: format::HeaderStart,
     current_tick: Option<i32>,
     raw: [u8; MAX_SNAPSHOT_SIZE],
     huffman: ArrayVec<[u8; MAX_SNAPSHOT_SIZE]>,
 }
 
-impl Reader {
-    pub fn new<W, R>(mut data: R, warn: &mut W) -> Result<Reader, ReadError>
+impl<'a> Reader<'a> {
+    pub fn new<W, R>(mut data: R, warn: &mut W) -> Result<Reader<'a>, ReadError>
     where
         W: Warn<Warning>,
-        R: io::Read + io::Seek + 'static,
+        R: io::Read + io::Seek + 'a,
     {
         let start = format::HeaderStart::read(&mut data)?;
         start.header.check(warn);

--- a/demo/src/writer.rs
+++ b/demo/src/writer.rs
@@ -32,8 +32,8 @@ impl WriteError {
     }
 }
 
-pub struct Writer {
-    file: Box<dyn SeekableWrite>,
+pub struct Writer<'a> {
+    file: Box<dyn SeekableWrite + 'a>,
     header: Header,
     prev_tick: Option<i32>,
     huffman: ArrayVec<[u8; MAX_SNAPSHOT_SIZE]>,
@@ -46,8 +46,8 @@ const WRITER_VERSION_DDNET: Version = Version::V6Ddnet;
 pub(crate) trait SeekableWrite: io::Write + io::Seek {}
 impl<T: io::Write + io::Seek> SeekableWrite for T {}
 
-impl Writer {
-    pub fn new<W: io::Write + io::Seek + 'static>(
+impl<'a> Writer<'a> {
+    pub fn new<W: io::Write + io::Seek + 'a>(
         file: W,
         net_version: &[u8],
         map_name: &[u8],
@@ -57,7 +57,7 @@ impl Writer {
         length: i32,
         timestamp: &[u8],
         map: &[u8],
-    ) -> Result<Writer, WriteError> {
+    ) -> Result<Writer<'a>, WriteError> {
         let mut writer = Writer {
             file: Box::new(file),
             header: Header {


### PR DESCRIPTION
Problem I want to solve
---

Currently, you can only pass `'static` readers/writers into the demo readers/writers.
This works for `File`s, but not for writing into `Vec<u8>`.
As we require `io::Seek` for both reader and writer, we would not write into `Vec<u8>` directly, but a `Cursor<&mut Vec<u8>>` should work.

Why RFC
---

I'm not sure about the implications of this change.
Introducing a lifetime typically makes using it more difficult.
This is apparent with the lifetime issues that arose.

Issues
---

New lifetime issues which I wasn't able to solve, I guess I disagree with the compiler on some level.

1. Weird lifetime issue in `tools/demo_read_write`.
2. Lifetime issue in `tools/teehistorian2demo`, where I tried to actually write into a `Cursor<Vec<u8>>`. (I also tried `Cursor<&mut Vec<u8>>` and that didn't work either.