### PR TITLE
gamenet: Add 0.7 server info fields

### DIFF
--- a/gamenet/generate/msg_system.py
+++ b/gamenet/generate/msg_system.py
@@ -70,7 +70,7 @@ SYSTEM_MSGS_0_7 = [
     ( 1, "info", "vital", "s:version s?:password i?:client_version"),
     ( 2, "map_change", "vital", "s:name i:crc i:size i:num_response_chunks_per_request i:chunk_size h:sha256"),
     ( 3, "map_data", "vital", "r:data"),
-    ( 4, "server_info", "vital", "r:data"),
+    ( 4, "server_info", "vital", "s:version s:name s:hostname s:map s:game_type i:flags i:skill_level i:num_players i:max_players i:num_clients i:max_clients"),
     ( 5, "con_ready", "vital", ""),
     ( 6, "snap", "", "i:tick i:delta_tick i:num_parts i:part i:crc d:data"),
     ( 7, "snap_empty", "", "i:tick i:delta_tick"),

--- a/gamenet/generate/spec/teeworlds-0.7.5.json
+++ b/gamenet/generate/spec/teeworlds-0.7.5.json
@@ -934,7 +934,17 @@
 			"id": 4,
 			"name": ["server", "info"],
 			"members": [
-				{"name": ["data"], "type": {"kind": "rest"}}
+				{"name": ["version"], "type": {"kind": "string", "disallow_cc": false}},
+				{"name": ["name"], "type": {"kind": "string", "disallow_cc": false}},
+				{"name": ["hostname"], "type": {"kind": "string", "disallow_cc": false}},
+				{"name": ["map"], "type": {"kind": "string", "disallow_cc": false}},
+				{"name": ["game", "type"], "type": {"kind": "string", "disallow_cc": false}},
+				{"name": ["flags"], "type": {"kind": "int32"}},
+				{"name": ["skill", "level"], "type": {"kind": "int32"}},
+				{"name": ["num", "players"], "type": {"kind": "int32"}},
+				{"name": ["max", "players"], "type": {"kind": "int32"}},
+				{"name": ["num", "clients"], "type": {"kind": "int32"}},
+				{"name": ["max", "clients"], "type": {"kind": "int32"}}
 			],
 			"attributes": []
 		},

--- a/gamenet/teeworlds-0.7/src/msg/system.rs
+++ b/gamenet/teeworlds-0.7/src/msg/system.rs
@@ -370,7 +370,17 @@ pub struct MapData<'a> {
 
 #[derive(Clone, Copy)]
 pub struct ServerInfo<'a> {
-    pub data: &'a [u8],
+    pub version: &'a [u8],
+    pub name: &'a [u8],
+    pub hostname: &'a [u8],
+    pub map: &'a [u8],
+    pub game_type: &'a [u8],
+    pub flags: i32,
+    pub skill_level: i32,
+    pub num_players: i32,
+    pub max_players: i32,
+    pub num_clients: i32,
+    pub max_clients: i32,
 }
 
 #[derive(Clone, Copy)]
@@ -561,20 +571,50 @@ impl<'a> fmt::Debug for MapData<'a> {
 impl<'a> ServerInfo<'a> {
     pub fn decode<W: Warn<Warning>>(warn: &mut W, _p: &mut Unpacker<'a>) -> Result<ServerInfo<'a>, Error> {
         let result = Ok(ServerInfo {
-            data: _p.read_rest()?,
+            version: _p.read_string()?,
+            name: _p.read_string()?,
+            hostname: _p.read_string()?,
+            map: _p.read_string()?,
+            game_type: _p.read_string()?,
+            flags: _p.read_int(warn)?,
+            skill_level: _p.read_int(warn)?,
+            num_players: _p.read_int(warn)?,
+            max_players: _p.read_int(warn)?,
+            num_clients: _p.read_int(warn)?,
+            max_clients: _p.read_int(warn)?,
         });
         _p.finish(warn);
         result
     }
     pub fn encode<'d, 's>(&self, mut _p: Packer<'d, 's>) -> Result<&'d [u8], CapacityError> {
-        _p.write_rest(self.data)?;
+        _p.write_string(self.version)?;
+        _p.write_string(self.name)?;
+        _p.write_string(self.hostname)?;
+        _p.write_string(self.map)?;
+        _p.write_string(self.game_type)?;
+        _p.write_int(self.flags)?;
+        _p.write_int(self.skill_level)?;
+        _p.write_int(self.num_players)?;
+        _p.write_int(self.max_players)?;
+        _p.write_int(self.num_clients)?;
+        _p.write_int(self.max_clients)?;
         Ok(_p.written())
     }
 }
 impl<'a> fmt::Debug for ServerInfo<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("ServerInfo")
-            .field("data", &pretty::Bytes::new(&self.data))
+            .field("version", &pretty::Bytes::new(&self.version))
+            .field("name", &pretty::Bytes::new(&self.name))
+            .field("hostname", &pretty::Bytes::new(&self.hostname))
+            .field("map", &pretty::Bytes::new(&self.map))
+            .field("game_type", &pretty::Bytes::new(&self.game_type))
+            .field("flags", &self.flags)
+            .field("skill_level", &self.skill_level)
+            .field("num_players", &self.num_players)
+            .field("max_players", &self.max_players)
+            .field("num_clients", &self.num_clients)
+            .field("max_clients", &self.max_clients)
             .finish()
     }
 }


### PR DESCRIPTION
Generated using

```bash
cd gamenet/generate
python3 serialize.py --version 0.7 raw/teeworlds-0.7.5.py > spec/teeworlds-0.7.5.json
cd ../../
./generate_all
```

Tested using the wireshark dissector

![image](https://github.com/heinrich5991/libtw2/assets/20344300/ecbcbc2f-bb34-4bf3-9634-e8276f03993e)
