### PR TITLE
Allow `ammo_count` of -1.

### DIFF
--- a/gamenet/ddnet/src/snap_obj.rs
+++ b/gamenet/ddnet/src/snap_obj.rs
@@ -1193,7 +1193,7 @@ impl Character {
             player_flags: in_range(_p.read_int()?, 0, 256)?,
             health: in_range(_p.read_int()?, 0, 10)?,
             armor: in_range(_p.read_int()?, 0, 10)?,
-            ammo_count: in_range(_p.read_int()?, 0, 10)?,
+            ammo_count: in_range(_p.read_int()?, -1, 10)?,
             weapon: enums::Weapon::from_i32(_p.read_int()?)?,
             emote: enums::Emote::from_i32(_p.read_int()?)?,
             attack_tick: positive(_p.read_int()?)?,
@@ -1204,7 +1204,7 @@ impl Character {
         assert!(0 <= self.player_flags && self.player_flags <= 256);
         assert!(0 <= self.health && self.health <= 10);
         assert!(0 <= self.armor && self.armor <= 10);
-        assert!(0 <= self.ammo_count && self.ammo_count <= 10);
+        assert!(-1 <= self.ammo_count && self.ammo_count <= 10);
         assert!(self.attack_tick >= 0);
         unsafe { slice::transmute(from_ref(self)) }
     }


### PR DESCRIPTION
fixes #119.

Relevant part:
https://github.com/heinrich5991/libtw2/compare/master...Jupeyy:pr_ammo_count_range?expand=1#diff-626857e30429c09e54dd9529f4e8c69532ee8eb362adbbb6364c987c3b25972eR1223-R1234

Dunno why rustfmt did what it did.
