### PR TITLE
doc/*.ksy: Fix compilation errors

### DIFF
--- a/doc/datafile_v4.ksy
+++ b/doc/datafile_v4.ksy
@@ -28,7 +28,7 @@ seq:
     repeat: expr
     repeat-expr: header.num_items
   - id: data
-    size: (_index == header.num_data - 1 ? header.data_size : data_offsets[_index + 1]) - data_offsets[_index]
+    size: '(_index == header.num_data - 1 ? header.data_size : data_offsets[_index + 1]) - data_offsets[_index]'
     repeat: expr
     repeat-expr: header.num_data
 types:

--- a/doc/demo.ksy
+++ b/doc/demo.ksy
@@ -97,7 +97,7 @@ types:
       # tick
       - id: tick_absolute
         type: s4
-        if: is_tick and (_root.header.version >= 5 ? not inline_tick_delta : tick_delta_v3 == 0)
+        if: 'is_tick and (_root.header.version >= 5 ? not inline_tick_delta : tick_delta_v3 == 0)'
 
       # non-tick
       - id: size_extern_8
@@ -111,8 +111,8 @@ types:
 
     instances:
       tick_delta:
-        value: _root.header.version >= 5 ? tick_delta_v5 : tick_delta_v3
-        if: is_tick and (_root.header.version >= 5 ? inline_tick_delta : tick_delta_v3 != 0)
+        value: '_root.header.version >= 5 ? tick_delta_v5 : tick_delta_v3'
+        if: 'is_tick and (_root.header.version >= 5 ? inline_tick_delta : tick_delta_v3 != 0)'
       size:
-        value: size_inline == 31 ? size_extern_16 : size_inline == 30 ? size_extern_8 : size_inline
+        value: 'size_inline == 31 ? size_extern_16 : size_inline == 30 ? size_extern_8 : size_inline'
         if: not is_tick

--- a/doc/map_v4.ksy
+++ b/doc/map_v4.ksy
@@ -30,7 +30,7 @@ seq:
   - id: data_items
     process: zlib
     type: dummy
-    size: (_index == header.num_data - 1 ? header.data_size : data_offsets[_index + 1]) - data_offsets[_index]
+    size: '(_index == header.num_data - 1 ? header.data_size : data_offsets[_index + 1]) - data_offsets[_index]'
     repeat: expr
     repeat-expr: header.num_data
 types:
@@ -238,10 +238,8 @@ types:
         type: s4
       - id: offset
         type: fixed_point(32.)
-        type: s4
       - id: parallax
         type: fixed_point(100.)
-        type: s4
       - id: first_layer_index
         type: s4
       - id: layer_amount
@@ -256,7 +254,6 @@ types:
       - id: clip_size
         if: version >= 2
         type: fixed_point(32.)
-        type: s4
       - id: name
         type: i32x3_string
   

--- a/doc/uncompressed_snap.ksy
+++ b/doc/uncompressed_snap.ksy
@@ -12,7 +12,7 @@ seq:
     repeat-expr: header.num_items
   - id: items
     type: item
-    size: (_index == header.num_items - 1 ? header.data_size : offsets[_index + 1]) - offsets[_index]
+    size: '(_index == header.num_items - 1 ? header.data_size : offsets[_index + 1]) - offsets[_index]'
     repeat: expr
     repeat-expr: header.num_items
 types:


### PR DESCRIPTION
The ternary/conditional operator '?' includes a ':', which is part of the YAML key/value syntax. Depending on the YAML parser, this in turn may produce parsing errors. Apparently they switched the YAML parser on the web IDE, so now all these YAML files didn't parse. In the documentation they do point this out as a compatibility concern and suggest to quote such expressions.
https://userunknownfactor.github.io/user_guide.html#_operators

Additionally, the new YAML parser pointed out duplicate keys, which I also fixed.