### PR TITLE
Fix map parsing Kaitai struct not supporting version 2 group items

### DIFF
--- a/doc/map_v4.ksy
+++ b/doc/map_v4.ksy
@@ -255,6 +255,7 @@ types:
         if: version >= 2
         type: fixed_point(32.)
       - id: name
+        if: version >= 3
         type: i32x3_string
   
   layer_item:


### PR DESCRIPTION
The group name was introduced in group item version 3. See reference implementation: https://github.com/ddnet/ddnet/blob/f02c17a673bc835444f565e1d3e1168a1372499a/src/game/editor/mapitems/map_io.cpp#L697-L699