### PR TITLE
Fix event loop sleep duration

### DIFF
--- a/event-loop/src/lib.rs
+++ b/event-loop/src/lib.rs
@@ -12,7 +12,6 @@ use libtw2_net::Net;
 use libtw2_socket::Socket;
 use libtw2_warn as warn;
 use log::LogLevel;
-use std::cmp;
 use std::fmt;
 
 pub use libtw2_net::collections;
@@ -100,7 +99,11 @@ impl Loop for SocketLoop {
             }
             self.disconnected.restore(disconnected);
 
-            let sleep_timeout = cmp::min(self.net.needs_tick(), application.needs_tick());
+            let sleep_timeout = if self.server {
+                self.net.needs_tick()
+            } else {
+                application.needs_tick()
+            };
             let sleep_duration = sleep_timeout.time_from(self.socket.time());
             if !self.server && sleep_duration.is_none() {
                 break;

--- a/event-loop/src/lib.rs
+++ b/event-loop/src/lib.rs
@@ -12,6 +12,7 @@ use libtw2_net::Net;
 use libtw2_socket::Socket;
 use libtw2_warn as warn;
 use log::LogLevel;
+use std::cmp;
 use std::fmt;
 
 pub use libtw2_net::collections;
@@ -99,11 +100,7 @@ impl Loop for SocketLoop {
             }
             self.disconnected.restore(disconnected);
 
-            let sleep_timeout = if self.server {
-                self.net.needs_tick()
-            } else {
-                application.needs_tick()
-            };
+            let sleep_timeout = cmp::min(self.net.needs_tick(), application.needs_tick());
             let sleep_duration = sleep_timeout.time_from(self.socket.time());
             if !self.server && sleep_duration.is_none() {
                 break;

--- a/net/src/time.rs
+++ b/net/src/time.rs
@@ -100,7 +100,7 @@ impl Timeout {
         self.to_opt().map(|t| {
             if t > time {
                 let us = t.as_usecs_since_epoch() - time.as_usecs_since_epoch();
-                Duration::new(us / 1_000_000_000, (us % 1_000_000_000).assert_u32())
+                Duration::from_micros(us)
             } else {
                 Duration::from_millis(0)
             }


### PR DESCRIPTION
Hello. I noticed that event loop for client isn't using desired sleep timeout because self.net.needs_tick() always returns lower value, so application needs_tick() becomes kinda useless.
Also in net Timeout microseconds are confused with nanoseconds, so returned duration is orders of magnitude lower than expected.
This PR fixes both issues.