### PR TITLE
Demo Seeking [wip]

### DIFF
--- a/demo/src/ddnet/reader.rs
+++ b/demo/src/ddnet/reader.rs
@@ -1,8 +1,11 @@
-use libtw2_common::digest::Sha256;
+use arrayvec::ArrayVec;
+use binrw::BinRead;
+use libtw2_common::num::Cast;
 use libtw2_gamenet_common::traits;
-use libtw2_gamenet_common::traits::MessageExt as _;
+use libtw2_gamenet_common::traits::MessageExt;
 use libtw2_gamenet_common::traits::Protocol;
 use libtw2_gamenet_common::traits::ProtocolStatic;
+use libtw2_huffman::instances::TEEWORLDS as HUFFMAN;
 use libtw2_packer::ExcessData;
 use libtw2_packer::IntUnpacker;
 use libtw2_packer::Unpacker;
@@ -19,20 +22,38 @@ use std::slice;
 use thiserror::Error;
 
 use crate::format;
-use crate::reader;
-use crate::DemoKind;
-use crate::RawChunk;
 
 #[derive(Error, Debug)]
 pub enum ReadError {
     #[error(transparent)]
-    Inner(#[from] reader::ReadError),
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Binrw(#[from] binrw::Error),
+    #[error(transparent)]
+    Huffman(#[from] libtw2_huffman::DecompressionError),
     #[error("Snap parsing - {0:?}")]
     Snap(snap::Error),
+    #[error("Unexpected data end during secondary decompression of message")]
+    MessageVarIntUnexpectedEnd,
+    #[error("Too big decompressed size during secondary decompression of message")]
+    MessageVarIntTooLong,
+    #[error("Tick number did not increase")]
+    NotIncreasingTick,
+    #[error("The first snapshot is only a snapshot-delta")]
+    StartingDeltaSnapshot,
+    #[error("The tick number overflowed")]
+    TickOverflow,
 }
 
+trait SeekableRead: io::Read + io::Seek {}
+impl<T: io::Read + io::Seek> SeekableRead for T {}
+
 pub struct DemoReader<'a, P: for<'p> Protocol<'p>> {
-    raw: reader::Reader<'a>,
+    data: Box<dyn SeekableRead + 'a>,
+    start: format::HeaderStart,
+    current_tick: Option<i32>,
+    raw: [u8; format::MAX_SNAPSHOT_SIZE],
+    huffman: ArrayVec<[u8; format::MAX_SNAPSHOT_SIZE]>,
     delta: Delta,
     snap: Snap,
     old_snap: Snap,
@@ -74,19 +95,25 @@ impl From<ExcessData> for Warning {
 pub enum Chunk<'a, P: Protocol<'a>> {
     Message(P::Game),
     Snapshot(slice::Iter<'a, (P::SnapObj, u16)>),
-    Tick(i32),
+    Tick { tick: i32, keyframe: bool },
     Invalid,
 }
 
 impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
-    pub fn new<R, W>(data: R, warn: &mut W) -> Result<Self, ReadError>
+    pub fn new<R, W>(mut data: R, warn: &mut W) -> Result<Self, ReadError>
     where
         R: io::Read + io::Seek + 'a,
         W: Warn<Warning>,
     {
-        let reader = reader::Reader::new(data, wrap(warn))?;
+        let start = format::HeaderStart::read(&mut data)?;
+        start.header.check(wrap(warn));
+        start.timeline_markers.check(wrap(warn));
         Ok(DemoReader {
-            raw: reader,
+            data: Box::new(data),
+            start: start,
+            current_tick: None,
+            raw: [0; format::MAX_SNAPSHOT_SIZE],
+            huffman: ArrayVec::new(),
             delta: Delta::new(),
             snap: Snap::empty(),
             old_snap: Snap::empty(),
@@ -96,76 +123,101 @@ impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
         })
     }
 
-    pub fn version(&self) -> format::Version {
-        self.raw.version()
-    }
-    pub fn net_version(&self) -> &[u8] {
-        self.raw.net_version()
-    }
-    pub fn map_name(&self) -> &[u8] {
-        self.raw.map_name()
-    }
-    pub fn map_size(&self) -> u32 {
-        self.raw.map_size()
-    }
-    pub fn map_data(&self) -> &[u8] {
-        self.raw.map_data()
-    }
-    pub fn map_crc(&self) -> u32 {
-        self.raw.map_crc()
-    }
-    pub fn kind(&self) -> DemoKind {
-        self.raw.kind()
-    }
-    pub fn length(&self) -> i32 {
-        self.raw.length()
-    }
-    pub fn timestamp(&self) -> &[u8] {
-        self.raw.timestamp()
-    }
-    pub fn timeline_markers(&self) -> &[i32] {
-        self.raw.timeline_markers()
-    }
-    pub fn map_sha256(&self) -> Option<Sha256> {
-        self.raw.map_sha256()
+    pub fn header(&self) -> &format::HeaderStart {
+        &self.start
     }
 
     pub fn next_chunk<W: Warn<Warning>>(
         &mut self,
         warn: &mut W,
     ) -> Result<Option<Chunk<'_, P>>, ReadError> {
-        match self.raw.read_chunk(wrap(warn))? {
-            None => return Ok(None),
-            Some(RawChunk::Unknown) => Ok(Some(Chunk::Invalid)),
-            Some(RawChunk::Tick { tick, .. }) => Ok(Some(Chunk::Tick(tick))),
-            Some(RawChunk::Message(msg)) => {
-                let mut unpacker = Unpacker::new_from_demo(msg);
-                match P::Game::decode(wrap(warn), &mut unpacker) {
-                    Ok(msg) => Ok(Some(Chunk::Message(msg))),
-                    Err(err) => {
-                        warn.warn(Warning::Gamenet(err));
-                        Ok(Some(Chunk::Invalid))
+        let Some(chunk_header) =
+            format::ChunkHeader::read(&mut self.data, self.start.version, wrap(warn))?
+        else {
+            return Ok(None);
+        };
+        match chunk_header {
+            format::ChunkHeader::Tick {
+                marker: format::TickMarker::Absolute(t),
+                keyframe,
+            } => {
+                if let Some(previous) = self.current_tick {
+                    if previous >= t {
+                        return Err(ReadError::NotIncreasingTick);
                     }
                 }
+                self.current_tick = Some(t);
+                Ok(Some(Chunk::Tick {
+                    tick: t,
+                    keyframe: keyframe,
+                }))
             }
-            Some(RawChunk::Snapshot(snap)) => {
-                self.snap
-                    .read(wrap(warn), &mut self.snap_read_buf, snap)
-                    .map_err(ReadError::Snap)?;
-                self.snapshot.build::<P, _>(warn, &self.snap)?;
-                Ok(Some(Chunk::Snapshot(self.snapshot.objects.iter())))
-            }
-            Some(RawChunk::SnapshotDelta(dt)) => {
-                let mut unpacker = Unpacker::new(dt);
-                self.delta
-                    .read(wrap(warn), P::obj_size, &mut unpacker)
-                    .map_err(ReadError::Snap)?;
-                self.old_snap
-                    .read_with_delta(wrap(warn), &self.snap, &self.delta)
-                    .map_err(ReadError::Snap)?;
-                mem::swap(&mut self.old_snap, &mut self.snap);
-                self.snapshot.build::<P, _>(warn, &self.snap)?;
-                Ok(Some(Chunk::Snapshot(self.snapshot.objects.iter())))
+            format::ChunkHeader::Tick {
+                marker: format::TickMarker::Delta(d),
+                keyframe,
+            } => match self.current_tick {
+                None => Err(ReadError::StartingDeltaSnapshot),
+                Some(t) => match t.checked_add(d.i32()) {
+                    None => Err(ReadError::TickOverflow),
+                    Some(new_t) => {
+                        self.current_tick = Some(new_t);
+                        Ok(Some(Chunk::Tick {
+                            tick: new_t,
+                            keyframe: keyframe,
+                        }))
+                    }
+                },
+            },
+            format::ChunkHeader::Data { kind, size } => {
+                let raw_data = &mut self.raw[..size.usize()];
+                self.data.read_exact(raw_data)?;
+                self.huffman.clear();
+                HUFFMAN.decompress(raw_data, &mut self.huffman)?;
+                match kind {
+                    format::DataKind::Unknown => Ok(Some(Chunk::Invalid)),
+                    format::DataKind::Snapshot => {
+                        self.snap
+                            .read(wrap(warn), &mut self.snap_read_buf, &self.huffman)
+                            .map_err(ReadError::Snap)?;
+                        self.snapshot.build::<P, _>(warn, &self.snap)?;
+                        Ok(Some(Chunk::Snapshot(self.snapshot.objects.iter())))
+                    }
+                    format::DataKind::SnapshotDelta => {
+                        let mut unpacker = Unpacker::new(&self.huffman);
+                        self.delta
+                            .read(wrap(warn), P::obj_size, &mut unpacker)
+                            .map_err(ReadError::Snap)?;
+                        self.old_snap
+                            .read_with_delta(wrap(warn), &self.snap, &self.delta)
+                            .map_err(ReadError::Snap)?;
+                        mem::swap(&mut self.old_snap, &mut self.snap);
+                        self.snapshot.build::<P, _>(warn, &self.snap)?;
+                        Ok(Some(Chunk::Snapshot(self.snapshot.objects.iter())))
+                    }
+                    format::DataKind::Message => {
+                        let mut unpacker = Unpacker::new(&self.huffman);
+                        let mut len = 0;
+                        let mut buffer = self.raw.chunks_mut(4);
+                        while !unpacker.is_empty() {
+                            let n: i32 = unpacker
+                                .read_int(wrap(warn))
+                                .map_err(|_| ReadError::MessageVarIntUnexpectedEnd)?;
+                            buffer
+                                .next()
+                                .ok_or(ReadError::MessageVarIntTooLong)?
+                                .copy_from_slice(&n.to_le_bytes());
+                            len += 4;
+                        }
+                        let mut unpacker = Unpacker::new_from_demo(&self.raw[..len]);
+                        match P::Game::decode(wrap(warn), &mut unpacker) {
+                            Ok(msg) => Ok(Some(Chunk::Message(msg))),
+                            Err(err) => {
+                                warn.warn(Warning::Gamenet(err));
+                                Ok(Some(Chunk::Invalid))
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/demo/src/ddnet/reader.rs
+++ b/demo/src/ddnet/reader.rs
@@ -99,6 +99,20 @@ pub enum Chunk<'a, P: Protocol<'a>> {
     Invalid,
 }
 
+fn apply_tickmarker(current_tick: Option<i32>, tm: format::TickMarker) -> Result<i32, ReadError> {
+    use format::TickMarker::*;
+    match (current_tick, tm) {
+        (None, Absolute(t)) => Ok(t),
+        (Some(prev), Absolute(t)) if t > prev => Ok(t),
+        (Some(_), Absolute(_)) => Err(ReadError::NotIncreasingTick),
+        (None, Delta(_)) => Err(ReadError::StartingDeltaSnapshot),
+        (Some(prev), Delta(d)) => match prev.checked_add(d.i32()) {
+            None => Err(ReadError::TickOverflow),
+            Some(t) => Ok(t),
+        },
+    }
+}
+
 impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
     pub fn new<R, W>(mut data: R, warn: &mut W) -> Result<Self, ReadError>
     where
@@ -137,37 +151,14 @@ impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
             return Ok(None);
         };
         match chunk_header {
-            format::ChunkHeader::Tick {
-                marker: format::TickMarker::Absolute(t),
-                keyframe,
-            } => {
-                if let Some(previous) = self.current_tick {
-                    if previous >= t {
-                        return Err(ReadError::NotIncreasingTick);
-                    }
-                }
-                self.current_tick = Some(t);
+            format::ChunkHeader::Tick { marker, keyframe } => {
+                let tick = apply_tickmarker(self.current_tick, marker)?;
+                self.current_tick = Some(tick);
                 Ok(Some(Chunk::Tick {
-                    tick: t,
+                    tick,
                     keyframe: keyframe,
                 }))
             }
-            format::ChunkHeader::Tick {
-                marker: format::TickMarker::Delta(d),
-                keyframe,
-            } => match self.current_tick {
-                None => Err(ReadError::StartingDeltaSnapshot),
-                Some(t) => match t.checked_add(d.i32()) {
-                    None => Err(ReadError::TickOverflow),
-                    Some(new_t) => {
-                        self.current_tick = Some(new_t);
-                        Ok(Some(Chunk::Tick {
-                            tick: new_t,
-                            keyframe: keyframe,
-                        }))
-                    }
-                },
-            },
             format::ChunkHeader::Data { kind, size } => {
                 let raw_data = &mut self.raw[..size.usize()];
                 self.data.read_exact(raw_data)?;
@@ -220,6 +211,93 @@ impl<'a, P: for<'p> Protocol<'p>> DemoReader<'a, P> {
                 }
             }
         }
+    }
+
+    pub fn stream_position(&mut self) -> io::Result<u64> {
+        self.data.stream_position()
+    }
+
+    /// Seeks the inner reader to the specified position.
+    /// Take care that the tick is a keyframe.
+    /// Otherwise, a snap delta will throw errors.
+    pub fn seek(&mut self, pos: u64) -> io::Result<()> {
+        self.data.seek(io::SeekFrom::Start(pos))?;
+        self.current_tick = None;
+        self.snap = std::mem::take(&mut self.snap).recycle().finish();
+        Ok(())
+    }
+
+    /// This method uses minimal IO to seek the keyframe identified by the tick parameter.
+    /// It will go to the keyframe with the equal tick, if it exists.
+    /// Otherwise it will go to the keyframe with the closest, lower tick.
+    /// Returns `None`, if there was no keyframe leading up to the requested tick, of if the tick lies in the past.
+    /// If `None` is returned, the internal state of the reader stayed untouched.
+    /// If `Some` is returned, it contains the tick of the found keyframe.
+    pub fn skip_to_keyframe<W>(
+        &mut self,
+        seek_tick: i32,
+        warn: &mut W,
+    ) -> Result<Option<i32>, ReadError>
+    where
+        W: Warn<Warning>,
+    {
+        let mut last_valid_position = self.data.stream_position()?;
+        let mut last_valid_tick = self.current_tick;
+        let mut tmp_tick = self.current_tick;
+        while let Ok(header) =
+            format::ChunkHeader::read(&mut self.data, self.start.version, wrap(warn))
+        {
+            let Some(header) = header else {
+                // End of the demo, go back to last valid position;
+                if last_valid_tick == self.current_tick {
+                    // We didn't find a better position than the original one.
+                    self.data.seek(io::SeekFrom::Start(last_valid_position))?;
+                    return Ok(None);
+                } else {
+                    // We properly seek, so we need to reset internal state.
+                    self.seek(last_valid_position)?;
+                    return Ok(last_valid_tick);
+                }
+            };
+            let this_header_position = self.data.stream_position()?;
+            match header {
+                format::ChunkHeader::Tick { marker, keyframe } => {
+                    let tick = apply_tickmarker(tmp_tick, marker)?;
+                    tmp_tick = Some(tick);
+                    if keyframe {
+                        match tick.cmp(&seek_tick) {
+                            std::cmp::Ordering::Less => {
+                                // Still to far back in the demo, might still be the best fit.
+                                last_valid_position = this_header_position;
+                                last_valid_tick = Some(tick);
+                            }
+                            std::cmp::Ordering::Equal => {
+                                // We found exactly the keyframe the user asked for :)
+                                self.data.seek(io::SeekFrom::Start(this_header_position))?;
+                                return Ok(Some(tick));
+                            }
+                            std::cmp::Ordering::Greater => {
+                                // We overshot the requested tick, go back to last keyframe.
+                                if last_valid_tick == self.current_tick {
+                                    // We didn't find a better position than the original one.
+                                    self.data.seek(io::SeekFrom::Start(last_valid_position))?;
+                                    return Ok(None);
+                                } else {
+                                    // We properly seek, so we need to reset internal state.
+                                    self.seek(last_valid_position)?;
+                                    return Ok(last_valid_tick);
+                                }
+                            }
+                        }
+                    }
+                }
+                format::ChunkHeader::Data { size, .. } => {
+                    // Skip past chunk data
+                    self.data.seek(io::SeekFrom::Current(size.i64()))?;
+                }
+            }
+        }
+        todo!()
     }
 }
 

--- a/demo/src/ddnet/writer.rs
+++ b/demo/src/ddnet/writer.rs
@@ -1,8 +1,13 @@
 use crate::format;
+use arrayvec::ArrayVec;
+use binrw::BinWrite;
+use libtw2_buffer as buffer;
 use libtw2_common::digest::Sha256;
+use libtw2_common::num::Cast;
 use libtw2_gamenet_common::traits::MessageExt as _;
 use libtw2_gamenet_common::traits::Protocol;
 use libtw2_gamenet_common::traits::SnapObj as _;
+use libtw2_huffman::instances::TEEWORLDS as HUFFMAN;
 use libtw2_packer::with_packer;
 use libtw2_snapshot::snap;
 use libtw2_snapshot::Delta;
@@ -12,8 +17,12 @@ use std::marker::PhantomData;
 use std::mem;
 use thiserror::Error;
 
+const WRITER_VERSION: format::Version = format::Version::V5;
+
 #[derive(Debug, Error)]
 pub enum WriteError {
+    #[error(transparent)]
+    BinRw(#[from] binrw::Error),
     #[error(transparent)]
     Inner(crate::WriteError),
     #[error("Snap creation - {0:?}")]
@@ -38,11 +47,16 @@ impl From<snap::BuilderError> for WriteError {
     }
 }
 
+pub(crate) trait SeekableWrite: io::Write + io::Seek {}
+impl<T: io::Write + io::Seek> SeekableWrite for T {}
+
 /// DDNet demo writer.
 ///
 /// Automatically writes snapshot deltas.
 pub struct DemoWriter<'a, P: for<'p> Protocol<'p>> {
-    inner: crate::Writer<'a>,
+    file: Box<dyn SeekableWrite + 'a>,
+    prev_tick: Option<i32>,
+    huffman: ArrayVec<[u8; format::MAX_SNAPSHOT_SIZE]>,
     // To verify the monotonic increase
     last_tick: i32,
     // Stores the last tick, in which a snapshot was written.
@@ -57,7 +71,7 @@ pub struct DemoWriter<'a, P: for<'p> Protocol<'p>> {
 
 impl<'a, P: for<'p> Protocol<'p>> DemoWriter<'a, P> {
     pub fn new<T: io::Write + io::Seek + 'a>(
-        file: T,
+        mut file: T,
         net_version: &[u8],
         map_name: &[u8],
         map_sha256: Option<Sha256>,
@@ -67,20 +81,36 @@ impl<'a, P: for<'p> Protocol<'p>> DemoWriter<'a, P> {
         timestamp: &[u8],
         map: &[u8],
     ) -> Result<Self, WriteError> {
-        let raw = crate::Writer::new(
-            file,
-            net_version,
-            map_name,
-            map_sha256,
-            map_crc,
-            kind,
+        let version = if map_sha256.is_some() {
+            format::Version::V6Ddnet
+        } else {
+            format::Version::V5
+        };
+        version.write(&mut file)?;
+        let header = format::Header {
+            net_version: format::CappedString::from_raw(net_version),
+            map_name: format::CappedString::from_raw(map_name),
+            map_size: map.len().assert_i32(),
+            map_crc: map_crc,
+            kind: kind,
             length,
-            timestamp,
-            map,
-        )?;
+            timestamp: format::CappedString::from_raw(timestamp),
+        };
+        header.write(&mut file)?;
+        format::TimelineMarkers {
+            amount: 0,
+            markers: [0; 64],
+        }
+        .write(&mut file)?;
+        if let Some(sha256) = map_sha256 {
+            format::MapSha256::new(sha256).write_le(&mut file)?;
+        }
+        map.write(&mut file)?;
 
         Ok(Self {
-            inner: raw,
+            file: Box::new(file),
+            prev_tick: None,
+            huffman: ArrayVec::new(),
             last_tick: -1,
             last_keyframe: None,
             snap: Snap::default(),
@@ -117,18 +147,27 @@ impl<'a, P: for<'p> Protocol<'p>> DemoWriter<'a, P> {
         let old_snap = mem::take(&mut self.snap);
         let new_snap = mem::take(&mut self.builder).finish();
 
-        self.inner.write_tick(is_keyframe, tick)?;
+        let tm = format::TickMarker::new(tick, self.prev_tick, is_keyframe, WRITER_VERSION);
+        format::ChunkHeader::Tick {
+            marker: tm,
+            keyframe: is_keyframe,
+        }
+        .write(&mut self.file, WRITER_VERSION)?;
+        self.prev_tick = Some(tick);
+
         if is_keyframe {
             let keys = &mut self.i32_buf;
+            self.buf.clear();
             with_packer(&mut self.buf, |p| new_snap.write(keys, p))
                 .map_err(|_| WriteError::TooLargeSnap)?;
-            self.inner.write_snapshot(&self.buf)?;
+            self.write_chunk_impl(format::DataKind::Snapshot)?;
         } else {
             self.delta.create(&old_snap, &new_snap);
             let delta = &self.delta;
+            self.buf.clear();
             with_packer(&mut self.buf, |p| delta.write(P::obj_size, p))
                 .map_err(|_| WriteError::TooLargeSnap)?;
-            self.inner.write_snapshot_delta(&self.buf)?;
+            self.write_chunk_impl(format::DataKind::SnapshotDelta)?;
         }
 
         // Snap deltas always rely on the snap of the last tick in the demo.
@@ -144,9 +183,41 @@ impl<'a, P: for<'p> Protocol<'p>> DemoWriter<'a, P> {
         Ok(())
     }
     pub fn write_msg(&mut self, msg: &<P as Protocol<'_>>::Game) -> Result<(), WriteError> {
-        with_packer(&mut self.buf, |p| msg.encode(p)).map_err(|_| WriteError::TooLongNetMsg)?;
-        self.inner.write_message(self.buf.as_slice())?;
+        // We reuse the huffman buffer as we need to do twint decoding twice.
+        self.huffman.clear();
+        with_packer(&mut self.huffman, |p| msg.encode(p)).map_err(|_| WriteError::TooLongNetMsg)?;
         self.buf.clear();
+        with_packer(
+            &mut self.buf,
+            |mut p| -> Result<(), buffer::CapacityError> {
+                for b in self.huffman.chunks(4) {
+                    // Get or return 0.
+                    fn g(bytes: &[u8], idx: usize) -> u8 {
+                        bytes.get(idx).cloned().unwrap_or(0)
+                    }
+                    p.write_int(i32::from_le_bytes([g(b, 0), g(b, 1), g(b, 2), g(b, 3)]))?;
+                }
+                Ok(())
+            },
+        )
+        .expect("overlong message");
+        self.write_chunk_impl(format::DataKind::Message)?;
+        Ok(())
+    }
+    fn write_chunk_impl(&mut self, kind: format::DataKind) -> Result<(), WriteError> {
+        let data = &self.buf;
+        self.huffman.clear();
+        HUFFMAN
+            .compress(data, &mut self.huffman)
+            .expect("too long compression");
+        format::ChunkHeader::Data {
+            kind,
+            size: self.huffman.len().assert_u16(),
+        }
+        .write(&mut self.file, format::Version::V5)?;
+        self.file
+            .write_all(&self.huffman)
+            .map_err(binrw::Error::Io)?;
         Ok(())
     }
 }

--- a/demo/src/format.rs
+++ b/demo/src/format.rs
@@ -67,15 +67,51 @@ pub enum RawChunk<'a> {
 
 #[derive(BinRead, BinWrite, Debug)]
 #[brw(big)]
-pub(crate) struct HeaderStart {
-    pub version: Version,
-    pub header: Header,
+pub struct HeaderStart {
+    pub(crate) version: Version,
+    pub(crate) header: Header,
     #[br(if(version >= Version::V4))]
-    pub timeline_markers: TimelineMarkers,
+    pub(crate) timeline_markers: TimelineMarkers,
     #[br(if(version == Version::V6Ddnet))]
-    pub map_sha256: Option<MapSha256>,
+    pub(crate) map_sha256: Option<MapSha256>,
     #[br(count = header.map_size)]
-    pub map: Vec<u8>,
+    pub(crate) map: Vec<u8>,
+}
+
+impl HeaderStart {
+    pub fn version(&self) -> Version {
+        self.version
+    }
+    pub fn net_version(&self) -> &[u8] {
+        self.header.net_version.raw()
+    }
+    pub fn map_name(&self) -> &[u8] {
+        self.header.map_name.raw()
+    }
+    pub fn map_size(&self) -> u32 {
+        self.header.map_size.assert_u32()
+    }
+    pub fn map_data(&self) -> &[u8] {
+        &self.map
+    }
+    pub fn map_crc(&self) -> u32 {
+        self.header.map_crc
+    }
+    pub fn kind(&self) -> DemoKind {
+        self.header.kind
+    }
+    pub fn length(&self) -> i32 {
+        self.header.length
+    }
+    pub fn timestamp(&self) -> &[u8] {
+        self.header.timestamp.raw()
+    }
+    pub fn timeline_markers(&self) -> &[i32] {
+        self.timeline_markers.markers()
+    }
+    pub fn map_sha256(&self) -> Option<Sha256> {
+        self.map_sha256.as_ref().map(|sha| Sha256(sha.sha_256))
+    }
 }
 
 #[derive(BinRead, BinWrite, Debug)]
@@ -210,7 +246,7 @@ const CHUNKSIZE_ONEBYTEFOLLOWS: u8 = 0b0001_1110;
 const CHUNKSIZE_TWOBYTESFOLLOW: u8 = 0b0001_1111;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum DataKind {
+pub enum DataKind {
     Snapshot,
     Message,
     SnapshotDelta,
@@ -224,13 +260,13 @@ pub(crate) enum TickMarker {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) enum ChunkHeader {
+pub enum ChunkHeader {
     Tick { marker: TickMarker, keyframe: bool },
     Data { kind: DataKind, size: u16 },
 }
 
 impl ChunkHeader {
-    pub(crate) fn read<R, W>(
+    pub fn read<R, W>(
         data: &mut R,
         version: Version,
         warn: &mut W,

--- a/tools/src/bin/demo_read_write.rs
+++ b/tools/src/bin/demo_read_write.rs
@@ -73,14 +73,14 @@ fn ddnet_read_write(input: &str, output: &str) -> Result<(), Box<dyn Error>> {
     let mut reader = ddnet::DemoReader::<DDNet>::new(input_file, &mut warn::Log)?;
     let mut writer = ddnet::DemoWriter::<DDNet>::new(
         output_file,
-        reader.net_version(),
-        reader.map_name(),
-        reader.map_sha256(),
-        reader.map_crc(),
-        reader.kind(),
-        reader.length(),
-        reader.timestamp(),
-        reader.map_data(),
+        reader.header().net_version(),
+        reader.header().map_name(),
+        reader.header().map_sha256(),
+        reader.header().map_crc(),
+        reader.header().kind(),
+        reader.header().length(),
+        reader.header().timestamp(),
+        reader.header().map_data(),
     )?;
     let mut last_tick = None;
     while let Some(chunk) = reader.next_chunk(&mut warn::Log)? {
@@ -90,7 +90,7 @@ fn ddnet_read_write(input: &str, output: &str) -> Result<(), Box<dyn Error>> {
                 None => eprintln!("Snapshot without tick"),
                 Some(t) => writer.write_snap(t, snap.map(|(obj, id)| (obj, *id)))?,
             },
-            ddnet::Chunk::Tick(t) => last_tick = Some(t),
+            ddnet::Chunk::Tick { tick, .. } => last_tick = Some(tick),
             ddnet::Chunk::Invalid => eprintln!("Invalid chunk!"),
         }
     }


### PR DESCRIPTION
Okay, I spend too much time on this already, and am still reconsidering everything each time I come back to this.
I want demo seeking, in order to implement a proper demo replayer (see #140).

Currently, in this branch, I merged the two demo reader abstractions into the higher level one. If this is the way to go is uncertain, here are some pros for each variant. However, I also left the lower abstraction level reader in, as it is used by libtw2 tools.

Two Readers:
- Clean separation between protocol-agnostic demo reading and protocol-aware demo reading (it might not be possible to write a stub-protocol in the current state that accepts any protocol)
- This is the current state, existing tools in libtw2 use the protocol agnostic reader (see demo_read_write, demo_info)

One Reader:
- One level of abstraction less (no duplication of methods, also one stack-buffer less)
- Smaller API surface
- The lower abstraction reader is not low enough for the efficient seeking, and also currently holds state (only the current tick). Exposing the functionality to read chunk headers is comparable in usefulness imo.

I'm really struggling to be decisive here and would like to hear thoughts on this (@heinrich5991).

Currently, I haven't properly tested the seeking and will do so still, so please don't merge yet.