### PR TITLE
snapshot: Optimize snapshot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "libtw2-warn",
  "rand 0.8.3",
  "rand_chacha 0.3.0",
+ "rustc-hash",
  "uuid",
  "vec_map",
 ]
@@ -1948,6 +1949,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustls-pemfile"

--- a/snapshot/Cargo.toml
+++ b/snapshot/Cargo.toml
@@ -13,6 +13,7 @@ libtw2-gamenet-common = { path = "../gamenet/common/" }
 libtw2-gamenet-snap = { path = "../gamenet/snap/" }
 libtw2-packer = { path = "../packer/" }
 libtw2-warn = { path = "../warn/" }
+rustc-hash = "1.1.0"
 uuid = ">=0.8.1,<2.0.0"
 vec_map = "0.8.0"
 

--- a/snapshot/benches/build.rs
+++ b/snapshot/benches/build.rs
@@ -61,11 +61,7 @@ mod traits {
     }
     pub trait RawSnap {
         type RawBuilder: RawBuilder<RawSnap = Self>;
-        fn write_to_ints<'a>(
-            &mut self,
-            buf: &mut Vec<i32>,
-            result: &'a mut [i32],
-        ) -> Result<&'a [i32], CapacityError>;
+        fn write_to_ints<'a>(&mut self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError>;
         fn recycle(self) -> Self::RawBuilder;
     }
 
@@ -93,12 +89,8 @@ mod traits {
     }
     impl RawSnap for libtw2_snap::RawSnap {
         type RawBuilder = libtw2_snap::RawBuilder;
-        fn write_to_ints<'a>(
-            &mut self,
-            buf: &mut Vec<i32>,
-            result: &'a mut [i32],
-        ) -> Result<&'a [i32], CapacityError> {
-            (&*self).write_to_ints(buf, result)
+        fn write_to_ints<'a>(&mut self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError> {
+            (&*self).write_to_ints(result)
         }
         fn recycle(self) -> libtw2_snap::RawBuilder {
             self.recycle()
@@ -128,12 +120,8 @@ mod traits {
     }
     impl RawSnap for reference_snap::RawSnap {
         type RawBuilder = reference_snap::RawBuilder;
-        fn write_to_ints<'a>(
-            &mut self,
-            buf: &mut Vec<i32>,
-            result: &'a mut [i32],
-        ) -> Result<&'a [i32], CapacityError> {
-            self.write_to_ints(buf, result)
+        fn write_to_ints<'a>(&mut self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError> {
+            self.write_to_ints(result)
         }
         fn recycle(self) -> reference_snap::RawBuilder {
             self.recycle()
@@ -166,13 +154,12 @@ fn snap_from_items<S: RawSnap>(items: &[Item]) -> S {
 
 fn bench_snapwrite<I: Implementation>(bencher: &mut Bencher, items: Vec<Item>) {
     let mut out = (0..16384).map(|_| 0).collect_vec();
-    let mut buffer = Vec::new();
     let mut builder_buf = Some(I::RawBuilder::default());
     bencher.iter(|| {
         let mut builder = builder_buf.take().unwrap();
         add_items(&mut builder, black_box(&items));
         let mut snap = builder.finish();
-        black_box(snap.write_to_ints(&mut buffer, &mut out).unwrap());
+        black_box(snap.write_to_ints(&mut out).unwrap());
         builder_buf = Some(snap.recycle());
     });
 }

--- a/snapshot/reference/src/snap.rs
+++ b/snapshot/reference/src/snap.rs
@@ -27,10 +27,10 @@ impl Default for RawBuilder {
 
 impl RawBuilder {
     fn inner_builder_mut(&mut self) -> *mut libc::c_void {
-        self.builder.as_mut_ptr() as *mut _
+        self.builder.as_mut_ptr().cast::<libc::c_void>()
     }
     pub fn new() -> RawBuilder {
-        Default::default()
+        RawBuilder::default()
     }
     pub fn add_item(&mut self, type_id: u16, id: u16, data: &[i32]) -> Result<(), Infallible> {
         unsafe {
@@ -47,7 +47,7 @@ impl RawBuilder {
     pub fn finish(mut self) -> RawSnap {
         const LEN: usize = 16384;
         assert!(self.serialized_snap.capacity() >= LEN);
-        let buffer = self.serialized_snap.as_mut_ptr() as *mut [i32; LEN];
+        let buffer = self.serialized_snap.as_mut_ptr().cast::<[i32; LEN]>();
         let written = unsafe { sys::snapshotbuilder_finish(self.inner_builder_mut(), buffer) };
         self.serialize_ok = usize::try_from(written)
             // TODO (MSRV 1.76): Use `.inspect()`
@@ -63,11 +63,7 @@ impl RawBuilder {
 pub struct RawSnap(RawBuilder);
 
 impl RawSnap {
-    pub fn write_to_ints<'a>(
-        &mut self,
-        _buf: &mut Vec<i32>,
-        result: &'a mut [i32],
-    ) -> Result<&'a [i32], CapacityError> {
+    pub fn write_to_ints<'a>(&mut self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError> {
         if !self.0.serialize_ok {
             return Err(CapacityError);
         }
@@ -103,15 +99,18 @@ impl Default for Delta {
 
 impl Delta {
     fn inner_delta_mut(&mut self) -> *mut libc::c_void {
-        self.builder.as_mut_ptr() as *mut _
+        self.builder.as_mut_ptr().cast::<libc::c_void>()
     }
     pub fn new() -> Delta {
-        Default::default()
+        Delta::default()
     }
     #[allow(unpredictable_function_pointer_comparisons)] // only used for caching
     fn handle_obj_size(&mut self, obj_size: fn(u16) -> Option<u32>) {
-        if self.prev_obj_size.is_none() {
+        if self.prev_obj_size != Some(obj_size) {
             self.prev_obj_size = Some(obj_size);
+            unsafe {
+                sys::snapshotdelta_init(self.inner_delta_mut());
+            }
             for type_ in 0..32768 {
                 if let Some(size) = obj_size(type_) {
                     unsafe {
@@ -123,8 +122,6 @@ impl Delta {
                     }
                 }
             }
-        } else if self.prev_obj_size != Some(obj_size) {
-            panic!("can only be called with a single `obj_size` function");
         }
     }
     pub fn create_raw_and_write_to_ints<'a>(
@@ -135,8 +132,9 @@ impl Delta {
         mut result: &'a mut [i32],
     ) -> Result<&'a [i32], CapacityError> {
         self.handle_obj_size(obj_size);
-        assert!(from.0.serialize_ok);
-        assert!(to.0.serialize_ok);
+        if !from.0.serialize_ok || !to.0.serialize_ok {
+            return Err(CapacityError);
+        }
         if result.len() > 16384 {
             result = &mut result[..16384];
         }

--- a/snapshot/src/format.rs
+++ b/snapshot/src/format.rs
@@ -189,10 +189,13 @@ pub fn apply_item_delta(
     assert!(delta.len() == out.len());
     match in_ {
         Some(in_) => {
-            if in_.len() != out.len() {
+            let len = out.len();
+            if in_.len() != len {
                 return Err(DeltaDifferingSizes);
             }
-            for i in 0..out.len() {
+            let in_ = &in_[..len];
+            let delta = &delta[..len];
+            for i in 0..len {
                 out[i] = in_[i].wrapping_add(delta[i]);
             }
         }
@@ -233,10 +236,13 @@ pub fn create_item_delta(
     assert!(to.len() == out.len());
     match from {
         Some(from) => {
-            if from.len() != to.len() {
+            let len = out.len();
+            if from.len() != len {
                 return Err(DeltaDifferingSizes);
             }
-            for i in 0..out.len() {
+            let from = &from[..len];
+            let to = &to[..len];
+            for i in 0..len {
                 out[i] = to[i].wrapping_sub(from[i]);
             }
         }

--- a/snapshot/src/snap.rs
+++ b/snapshot/src/snap.rs
@@ -28,18 +28,87 @@ use libtw2_packer::Unpacker;
 use libtw2_warn::wrap;
 use libtw2_warn::Ignore;
 use libtw2_warn::Warn;
+use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use std::cmp;
-use std::collections::btree_map;
-use std::collections::BTreeMap;
-use std::collections::BTreeSet;
+use std::collections::hash_map;
 use std::fmt;
-use std::iter;
 use std::mem;
 use std::ops;
 use uuid::Uuid;
 
 pub const MAX_SNAPSHOT_SIZE: usize = 64 * 1024; // 64 KB
 pub const MAX_SNAPSHOT_ITEMS: usize = 1024;
+
+#[derive(Clone, Copy, Default, Eq, PartialEq)]
+struct SeenEntry {
+    key: u32,
+    gen: u32,
+}
+
+#[derive(Clone, Default)]
+struct SeenKeys {
+    entries: Vec<SeenEntry>,
+    gen: u32,
+    len: usize,
+}
+
+impl SeenKeys {
+    #[inline]
+    fn ensure_allocated(&mut self) {
+        if self.entries.is_empty() {
+            const CAP: usize = MAX_SNAPSHOT_ITEMS * 2;
+            self.entries = vec![SeenEntry::default(); CAP];
+            self.gen = 1;
+            self.len = 0;
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        if self.entries.is_empty() {
+            return;
+        }
+        self.len = 0;
+        self.gen = self.gen.wrapping_add(1);
+        if self.gen == 0 {
+            self.entries.fill(SeenEntry::default());
+            self.gen = 1;
+        }
+    }
+
+    #[inline]
+    fn insert(&mut self, key: i32) -> bool {
+        self.ensure_allocated();
+        // Hard guard: a full table makes
+        // the open-addressing probe below loop forever. Builder::add_item caps the item count
+        // upstream, but this is the last line of defense against a main-thread hang if a
+        // caller ever forgets to.
+        if self.len * 2 >= self.entries.len() {
+            return false;
+        }
+
+        let key_u32 = key as u32;
+        let mask = self.entries.len() - 1;
+        debug_assert!(self.entries.len().is_power_of_two());
+
+        // Very cheap multiplicative hash; key already has decent entropy.
+        let mut idx = (key_u32.wrapping_mul(0x9E37_79B1) as usize) & mask;
+        loop {
+            let entry = &mut self.entries[idx];
+            if entry.gen != self.gen {
+                entry.key = key_u32;
+                entry.gen = self.gen;
+                self.len += 1;
+                return true;
+            }
+            if entry.key == key_u32 {
+                return false;
+            }
+            idx = (idx + 1) & mask;
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
@@ -98,10 +167,28 @@ impl From<UnexpectedEnd> for Error {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Default)]
 pub struct RawSnap {
-    offsets: BTreeMap<i32, ops::Range<u32>>,
+    items: Vec<RawEntry>,
     buf: Vec<i32>,
+    seen: SeenKeys,
+}
+
+impl Clone for RawSnap {
+    fn clone(&self) -> RawSnap {
+        RawSnap {
+            items: self.items.clone(),
+            buf: self.buf.clone(),
+            seen: self.seen.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RawEntry {
+    key: i32,
+    start: u32,
+    end: u32,
 }
 
 impl RawSnap {
@@ -109,90 +196,115 @@ impl RawSnap {
         Default::default()
     }
     fn clear(&mut self) {
-        self.offsets.clear();
+        self.items.clear();
         self.buf.clear();
+        self.seen.clear();
     }
-    fn item_from_offset(&self, offset: ops::Range<u32>) -> &[i32] {
-        &self.buf[to_usize(offset)]
+    #[inline]
+    fn item_from_entry(&self, entry: &RawEntry) -> &[i32] {
+        &self.buf[to_usize(entry.start..entry.end)]
     }
     pub fn item(&self, raw_type_id: u16, id: u16) -> Option<&[i32]> {
-        self.offsets
-            .get(&key(raw_type_id, id))
-            .map(|o| &self.buf[to_usize(o.clone())])
+        self.items
+            .binary_search_by_key(&(key(raw_type_id, id) as u32), |e| e.key as u32)
+            .ok()
+            .map(|idx| self.item_from_entry(&self.items[idx]))
     }
     pub fn items(&self) -> RawItems<'_> {
         RawItems {
             snap: self,
-            iter: self.offsets.iter(),
+            iter: self.items.iter(),
         }
     }
-    fn serialized_ints_size(num_items: usize, num_item_data_i32s: usize) -> usize {
-        // snapshot:
-        //     [ 4] data_size
-        //     [ 4] num_items
-        //     [*4] item_offsets
-        //     [  ] items
-        //
-        // item:
-        //     [ 2] id
-        //     [ 2] type_id
-        //     [  ] data
-        mem::size_of::<i32>() * (2 + num_items + num_items + num_item_data_i32s)
+    fn sort_items(&mut self) {
+        if self.items.len() >= 2 {
+            let mut grouped = true;
+            let mut prev = key_to_raw_type_id(self.items[0].key);
+            for e in &self.items[1..] {
+                let cur = key_to_raw_type_id(e.key);
+                if cur < prev {
+                    grouped = false;
+                    break;
+                }
+                prev = cur;
+            }
+            if grouped {
+                let mut start = 0usize;
+                while start < self.items.len() {
+                    let t = key_to_raw_type_id(self.items[start].key);
+                    let mut end = start + 1;
+                    while end < self.items.len() && key_to_raw_type_id(self.items[end].key) == t {
+                        end += 1;
+                    }
+                    if end - start > 1 {
+                        self.items[start..end].sort_unstable_by_key(|e| key_to_id(e.key) as u32);
+                    }
+                    start = end;
+                }
+                return;
+            }
+        }
+
+        self.items.sort_unstable_by_key(|e| e.key as u32);
     }
-    fn prepare_item_vacant<'a>(
-        num_items: usize,
-        entry: btree_map::VacantEntry<'a, i32, ops::Range<u32>>,
-        buf: &mut Vec<i32>,
-        size: usize,
-    ) -> Result<&'a mut ops::Range<u32>, BuilderError> {
-        let offset = buf.len();
+    #[inline]
+    fn would_fit(num_items: usize, num_item_data_i32s: usize) -> bool {
+        const MAX_INTS: usize = MAX_SNAPSHOT_SIZE / mem::size_of::<i32>();
+        2 + (2 * num_items) + num_item_data_i32s <= MAX_INTS
+    }
+    fn push_item_uninit(&mut self, key: i32, size: usize) -> Result<ops::Range<u32>, BuilderError> {
+        let num_items = self.items.len();
         if num_items + 1 > MAX_SNAPSHOT_ITEMS {
             return Err(BuilderError::TooManyItems);
         }
-        if RawSnap::serialized_ints_size(num_items + 1, offset + size) > MAX_SNAPSHOT_SIZE {
+
+        let offset = self.buf.len();
+        if !RawSnap::would_fit(num_items + 1, offset + size) {
             return Err(BuilderError::TooLongSnap);
         }
         let start = offset.assert_u32();
         let end = (offset + size).assert_u32();
-        buf.extend(iter::repeat(0).take(size));
-        Ok(entry.insert(start..end))
+        self.buf.resize(offset + size, 0);
+        self.items.push(RawEntry { key, start, end });
+        Ok(start..end)
     }
-    fn add_item_uninitialized(
-        &mut self,
-        raw_type_id: u16,
-        id: u16,
-        size: usize,
-    ) -> Result<&mut [i32], BuilderError> {
-        let num_items = self.offsets.len();
-        let offset = match self.offsets.entry(key(raw_type_id, id)) {
-            btree_map::Entry::Occupied(..) => return Err(BuilderError::DuplicateKey),
-            btree_map::Entry::Vacant(v) => {
-                RawSnap::prepare_item_vacant(num_items, v, &mut self.buf, size)?
-            }
+    fn push_item_copy(&mut self, key: i32, data: &[i32]) -> Result<(), BuilderError> {
+        let num_items = self.items.len();
+        if num_items + 1 > MAX_SNAPSHOT_ITEMS {
+            return Err(BuilderError::TooManyItems);
         }
-        .clone();
-        Ok(&mut self.buf[to_usize(offset)])
-    }
-    fn add_item(&mut self, raw_type_id: u16, id: u16, data: &[i32]) -> Result<(), BuilderError> {
-        self.add_item_uninitialized(raw_type_id, id, data.len())?
-            .copy_from_slice(data);
+
+        let offset = self.buf.len();
+        let size = data.len();
+        // Inline the size check, this is hot in snapshot construction.
+        const MAX_INTS: usize = MAX_SNAPSHOT_SIZE / mem::size_of::<i32>();
+        if 2 + (2 * (num_items + 1)) + (offset + size) > MAX_INTS {
+            return Err(BuilderError::TooLongSnap);
+        }
+        let start = offset.assert_u32();
+        let end = (offset + size).assert_u32();
+        self.items.push(RawEntry { key, start, end });
+        self.buf.extend_from_slice(data);
         Ok(())
     }
-    fn prepare_item(
+    fn push_copy_key(&mut self, key: i32, data: &[i32]) -> Result<(), Error> {
+        self.push_item_copy(key, data).map_err(Error::from)
+    }
+    fn push_apply_key(
         &mut self,
-        raw_type_id: u16,
-        id: u16,
-        size: usize,
-    ) -> Result<&mut [i32], Error> {
-        let num_items = self.offsets.len();
-        let offset = match self.offsets.entry(key(raw_type_id, id)) {
-            btree_map::Entry::Occupied(o) => o.into_mut(),
-            btree_map::Entry::Vacant(v) => {
-                RawSnap::prepare_item_vacant(num_items, v, &mut self.buf, size)?
-            }
-        }
-        .clone();
-        Ok(&mut self.buf[to_usize(offset)])
+        key: i32,
+        in_data: Option<&[i32]>,
+        diff: &[i32],
+    ) -> Result<(), Error> {
+        let range = self
+            .push_item_uninit(key, diff.len())
+            .map_err(Error::from)?;
+        let out = &mut self.buf[to_usize(range)];
+        apply_item_delta(in_data, diff, out)?;
+        Ok(())
+    }
+    fn push_item(&mut self, raw_type_id: u16, id: u16, data: &[i32]) -> Result<(), BuilderError> {
+        self.push_item_copy(key(raw_type_id, id), data)
     }
     pub fn read<W: Warn<Warning>>(
         &mut self,
@@ -214,34 +326,34 @@ impl RawSnap {
             }
         }
 
-        self.read_from_ints(warn, &buf)
+        self.read_from_ints(warn, buf)
     }
     pub fn read_from_ints<W: Warn<Warning>>(
         &mut self,
         warn: &mut W,
-        data: &[i32],
+        ints: &[i32],
     ) -> Result<(), Error> {
         self.clear();
 
-        let mut unpacker = IntUnpacker::new(data);
+        let mut unpacker = IntUnpacker::new(ints);
         let header = SnapHeader::decode_obj(&mut unpacker)?;
-        let data = unpacker.as_slice();
+        let ints = unpacker.as_slice();
 
         let offsets_len = header.num_items.assert_usize();
-        if data.len() < offsets_len {
+        if ints.len() < offsets_len {
             return Err(Error::OffsetsUnpacking);
         }
         if header.data_size % 4 != 0 {
             return Err(Error::InvalidOffset);
         }
         let items_len = (header.data_size / 4).assert_usize();
-        match (offsets_len + items_len).cmp(&data.len()) {
+        match (offsets_len + items_len).cmp(&ints.len()) {
             cmp::Ordering::Less => warn.warn(Warning::ExcessSnapData),
             cmp::Ordering::Equal => {}
             cmp::Ordering::Greater => return Err(Error::ItemsUnpacking),
         }
 
-        let (offsets, item_data) = data.split_at(offsets_len);
+        let (offsets, item_data) = ints.split_at(offsets_len);
         let item_data = &item_data[..items_len];
 
         let mut offsets = offsets.iter();
@@ -268,7 +380,33 @@ impl RawSnap {
                 }
                 let raw_type_id = key_to_raw_type_id(item_data[prev_offset]);
                 let id = key_to_id(item_data[prev_offset]);
-                self.add_item(raw_type_id, id, &item_data[prev_offset + 1..offset])?;
+                let item_payload = &item_data[prev_offset + 1..offset];
+                let range = self
+                    .push_item_uninit(key(raw_type_id, id), item_payload.len())
+                    .map_err(Error::from)?;
+                let start = range.start.usize();
+                let end = range.end.usize();
+                let desired_end = start + item_payload.len();
+                if end != desired_end {
+                    // `push_item_uninit` appends, so the written range must end at the buffer end.
+                    if end != self.buf.len() {
+                        return Err(Error::ItemsUnpacking);
+                    }
+                    if !RawSnap::would_fit(self.items.len(), desired_end) {
+                        return Err(Error::TooLongSnap);
+                    }
+                    self.buf.resize(desired_end, 0);
+                    let last = self.items.last_mut().ok_or(Error::ItemsUnpacking)?;
+                    if last.start != range.start || last.end != range.end {
+                        return Err(Error::ItemsUnpacking);
+                    }
+                    last.end = desired_end.assert_u32();
+                }
+                let dst = self
+                    .buf
+                    .get_mut(start..desired_end)
+                    .ok_or(Error::ItemsUnpacking)?;
+                dst.copy_from_slice(item_payload);
             } else if offset != 0 {
                 // First offset must be 0.
                 return Err(Error::InvalidOffset);
@@ -278,6 +416,12 @@ impl RawSnap {
 
             if finished {
                 break;
+            }
+        }
+        self.sort_items();
+        for w in self.items.windows(2) {
+            if w[0].key == w[1].key {
+                return Err(Error::DuplicateKey);
             }
         }
         Ok(())
@@ -293,28 +437,83 @@ impl RawSnap {
     {
         self.clear();
 
+        let mut index = 0;
+        let mut updates_index = 0;
+        let mut deleted_index = 0;
         let mut num_deletions = 0;
-        for item in from.items() {
-            if !delta.deleted_items.contains(&item.key()) {
-                let out = self.prepare_item(item.raw_type_id, item.id, item.data.len())?;
-                out.copy_from_slice(item.data);
-            } else {
-                num_deletions += 1;
+
+        let mut is_deleted = |key: i32| -> bool {
+            while deleted_index < delta.deleted_items.keys.len() {
+                let del_key = delta.deleted_items.keys[deleted_index];
+                if (del_key as u32) < (key as u32) {
+                    deleted_index += 1;
+                } else if del_key == key {
+                    return true;
+                } else {
+                    break;
+                }
+            }
+            false
+        };
+
+        while index < from.items.len() || updates_index < delta.updated_items.len() {
+            let from_key = from.items.get(index).map(|e| e.key);
+            let update_key = delta.updated_items.get(updates_index).map(|e| e.key);
+
+            match (from_key, update_key) {
+                (Some(from_key), Some(update_key)) => match (from_key as u32)
+                    .cmp(&(update_key as u32))
+                {
+                    cmp::Ordering::Less => {
+                        if is_deleted(from_key) {
+                            num_deletions += 1;
+                        } else {
+                            self.push_copy_key(from_key, from.item_from_entry(&from.items[index]))?;
+                        }
+                        index += 1;
+                    }
+                    cmp::Ordering::Greater => {
+                        let diff =
+                            &delta.buf[to_usize(delta.updated_items[updates_index].range.clone())];
+                        self.push_apply_key(update_key, None, diff)?;
+                        updates_index += 1;
+                    }
+                    cmp::Ordering::Equal => {
+                        let in_data = if is_deleted(from_key) {
+                            num_deletions += 1;
+                            None
+                        } else {
+                            Some(from.item_from_entry(&from.items[index]))
+                        };
+                        let diff =
+                            &delta.buf[to_usize(delta.updated_items[updates_index].range.clone())];
+                        self.push_apply_key(from_key, in_data, diff)?;
+                        index += 1;
+                        updates_index += 1;
+                    }
+                },
+                (Some(fk), None) => {
+                    if is_deleted(fk) {
+                        num_deletions += 1;
+                    } else {
+                        self.push_copy_key(fk, from.item_from_entry(&from.items[index]))?;
+                    }
+                    index += 1;
+                }
+                (None, Some(uk)) => {
+                    let diff =
+                        &delta.buf[to_usize(delta.updated_items[updates_index].range.clone())];
+                    self.push_apply_key(uk, None, diff)?;
+                    updates_index += 1;
+                }
+                (None, None) => break,
             }
         }
+
         if num_deletions != delta.deleted_items.len() {
             warn.warn(Warning::UnknownDelete);
         }
-
-        for (&key, offset) in &delta.updated_items {
-            let raw_type_id = key_to_raw_type_id(key);
-            let id = key_to_id(key);
-            let diff = &delta.buf[to_usize(offset.clone())];
-            let out = self.prepare_item(raw_type_id, id, diff.len())?;
-            let in_ = from.item(raw_type_id, id);
-
-            apply_item_delta(in_, diff, out)?;
-        }
+        self.sort_items();
         Ok(())
     }
     fn write_impl<F: FnMut(i32) -> Result<(), CapacityError>>(
@@ -322,45 +521,41 @@ impl RawSnap {
         buf: &mut Vec<i32>,
         mut write_int: F,
     ) -> Result<(), CapacityError> {
-        assert!(self.offsets.len() <= MAX_SNAPSHOT_ITEMS);
+        assert!(self.items.len() <= MAX_SNAPSHOT_ITEMS);
         let mut written = 0;
         let mut write_int = |i| {
             written += mem::size_of::<i32>();
             write_int(i)
         };
-        let keys = buf;
-        keys.clear();
-        keys.extend(self.offsets.keys().cloned());
-        keys.sort_unstable_by_key(|&k| k as u32);
+        buf.clear();
         let data_size = self
             .buf
             .len()
-            .checked_add(self.offsets.len())
+            .checked_add(self.items.len())
             .expect("snap size overflow")
             .checked_mul(mem::size_of::<i32>())
             .expect("snap size overflow")
             .assert_i32();
         write_int(data_size)?;
-        let num_items = self.offsets.len().assert_i32();
+        let num_items = self.items.len().assert_i32();
         write_int(num_items)?;
 
         let mut offset = 0;
-        for &key in &*keys {
+        for entry in &self.items {
             write_int(offset)?;
-            let key_offset = self.offsets[&key].clone();
+            let data_len = (entry.end - entry.start).usize();
             offset = offset
                 .checked_add(
-                    (key_offset.end - key_offset.start + 1)
-                        .usize()
+                    (data_len + 1)
                         .checked_mul(mem::size_of::<i32>())
                         .expect("item size overflow")
                         .assert_i32(),
                 )
                 .expect("offset overflow");
         }
-        for &key in &*keys {
-            write_int(key)?;
-            for &i in &self.buf[to_usize(self.offsets[&key].clone())] {
+        for entry in &self.items {
+            write_int(entry.key)?;
+            for &i in self.item_from_entry(entry) {
                 write_int(i)?;
             }
         }
@@ -375,19 +570,38 @@ impl RawSnap {
         self.write_impl(buf, |int| p.write_int(int))?;
         Ok(p.written())
     }
-    pub fn write_to_ints<'a>(
-        &self,
-        buf: &mut Vec<i32>,
-        result: &'a mut [i32],
-    ) -> Result<&'a [i32], CapacityError> {
-        let mut iter = result.iter_mut();
-        self.write_impl(buf, |int| {
-            *iter.next().ok_or(CapacityError)? = int;
-            Ok(())
-        })?;
-        let remaining = iter.len();
-        let len = result.len() - remaining;
-        Ok(&result[..len])
+    pub fn write_to_ints<'a>(&self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError> {
+        let num_items = self.items.len();
+        let total_len = 2 + (num_items * 2) + self.buf.len();
+        if result.len() < total_len {
+            return Err(CapacityError);
+        }
+
+        let mut idx = 0;
+        let data_size = ((self.buf.len() + num_items) * mem::size_of::<i32>()).assert_i32();
+        result[idx] = data_size;
+        idx += 1;
+        result[idx] = num_items.assert_i32();
+        idx += 1;
+
+        let mut offset: i32 = 0;
+        for entry in &self.items {
+            result[idx] = offset;
+            idx += 1;
+            let data_len = (entry.end - entry.start).usize();
+            offset += ((data_len + 1) * mem::size_of::<i32>()).assert_i32();
+        }
+
+        for entry in &self.items {
+            result[idx] = entry.key;
+            idx += 1;
+            let start = entry.start.usize();
+            let len = (entry.end - entry.start).usize();
+            result[idx..idx + len].copy_from_slice(&self.buf[start..start + len]);
+            idx += len;
+        }
+
+        Ok(&result[..idx])
     }
     pub fn crc(&self) -> i32 {
         self.buf.iter().fold(0, |s, &a| s.wrapping_add(a))
@@ -395,6 +609,14 @@ impl RawSnap {
     pub fn recycle(mut self) -> RawBuilder {
         self.clear();
         RawBuilder { snap: self }
+    }
+
+    pub fn recycle_sorted(mut self) -> RawBuilderSorted {
+        self.clear();
+        RawBuilderSorted {
+            snap: self,
+            last_key: None,
+        }
     }
 }
 
@@ -408,7 +630,7 @@ fn read_int_err<R: ReadInt, W: Warn<Warning>>(
 
 pub struct RawItems<'a> {
     snap: &'a RawSnap,
-    iter: btree_map::Iter<'a, i32, ops::Range<u32>>,
+    iter: std::slice::Iter<'a, RawEntry>,
 }
 
 impl<'a> Iterator for RawItems<'a> {
@@ -416,7 +638,7 @@ impl<'a> Iterator for RawItems<'a> {
     fn next(&mut self) -> Option<RawItem<'a>> {
         self.iter
             .next()
-            .map(|(&k, o)| RawItem::from_key(k, self.snap.item_from_offset(o.clone())))
+            .map(|entry| RawItem::from_key(entry.key, self.snap.item_from_entry(entry)))
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
@@ -446,7 +668,7 @@ impl fmt::Debug for RawSnap {
 #[derive(Clone, Default)]
 pub struct Snap {
     raw: RawSnap,
-    extended_types: BTreeMap<Uuid, u16>,
+    extended_types: FxHashMap<Uuid, u16>,
 }
 
 impl Snap {
@@ -489,28 +711,24 @@ impl Snap {
     }
     fn build_from_raw<W: Warn<Warning>>(&mut self, warn: &mut W) -> Result<(), Error> {
         self.extended_types.clear();
-        let mut prev_checked_raw_type_id = None;
-        for (&item_key, offset) in &self.raw.offsets {
+        let mut seen_extended_raw_type_ids = FxHashSet::<u16>::default();
+        for entry in &self.raw.items {
+            let item_key = entry.key;
             let raw_type_id = key_to_raw_type_id(item_key);
             if raw_type_id == TYPE_ID_EX {
-                let item_data = self.raw.item_from_offset(offset.clone());
+                let id = key_to_id(item_key);
+                let item_data = self.raw.item_from_entry(entry);
                 let uuid = item_data_to_uuid(warn, item_data).ok_or(Error::InvalidUuidType)?;
-                if self.extended_types.insert(uuid, raw_type_id).is_some() {
+                if self.extended_types.insert(uuid, id).is_some() {
                     return Err(Error::DuplicateUuidType);
                 }
             } else if raw_type_id >= OFFSET_EXTENDED_TYPE_ID {
-                if Some(raw_type_id) == prev_checked_raw_type_id {
-                    continue;
-                }
-                if self
-                    .raw
-                    .offsets
-                    .get(&key(TYPE_ID_EX, raw_type_id))
-                    .is_none()
-                {
-                    return Err(Error::MissingUuidType);
-                }
-                prev_checked_raw_type_id = Some(raw_type_id);
+                seen_extended_raw_type_ids.insert(raw_type_id);
+            }
+        }
+        for raw_type_id in seen_extended_raw_type_ids {
+            if self.raw.item(TYPE_ID_EX, raw_type_id).is_none() {
+                return Err(Error::MissingUuidType);
             }
         }
         Ok(())
@@ -554,12 +772,8 @@ impl Snap {
     ) -> Result<&'d [u8], CapacityError> {
         self.raw.write(buf, p)
     }
-    pub fn write_to_ints<'a>(
-        &self,
-        buf: &mut Vec<i32>,
-        result: &'a mut [i32],
-    ) -> Result<&'a [i32], CapacityError> {
-        self.raw.write_to_ints(buf, result)
+    pub fn write_to_ints<'a>(&self, result: &'a mut [i32]) -> Result<&'a [i32], CapacityError> {
+        self.raw.write_to_ints(result)
     }
     pub fn crc(&self) -> i32 {
         self.raw.crc()
@@ -570,13 +784,16 @@ impl Snap {
     /// the snapshot delta smaller.
     pub fn recycle(mut self) -> Builder {
         let mut next_type_id = OFFSET_EXTENDED_TYPE_ID;
-        for &key in self.raw.offsets.keys() {
-            let raw_type_id = key_to_raw_type_id(key);
-            let id = key_to_id(key);
-            const _: () = assert!(TYPE_ID_EX == 0);
-            if raw_type_id != TYPE_ID_EX {
-                break;
-            }
+        // raw.items is guaranteed to be sorted by Snap invariants
+        // (Builder::finish, read_from_ints, read_with_delta).
+        let iter = self
+            .raw
+            .items
+            .iter()
+            .filter(|e| key_to_raw_type_id(e.key) == TYPE_ID_EX)
+            .map(|e| key_to_id(e.key));
+
+        for id in iter {
             // Make sure we'll have space for at least 256 additional extended types.
             if id < next_type_id + 256 {
                 next_type_id = id + 1;
@@ -586,9 +803,11 @@ impl Snap {
         for (&uuid, &raw_type_id) in &self.extended_types {
             // It fit last time, it's going to fit this time.
             self.raw
-                .add_item(TYPE_ID_EX, raw_type_id, &uuid_to_item_data(uuid))
+                .push_item(TYPE_ID_EX, raw_type_id, &uuid_to_item_data(uuid))
                 .unwrap();
+            self.raw.seen.insert(key(TYPE_ID_EX, raw_type_id));
         }
+        self.raw.sort_items();
         Builder {
             snap: self,
             next_type_id,
@@ -648,9 +867,65 @@ impl fmt::Debug for Snap {
 
 #[derive(Clone, Default)]
 pub struct Delta {
-    deleted_items: BTreeSet<i32>,
-    updated_items: BTreeMap<i32, ops::Range<u32>>,
+    deleted_items: DeletedItems,
+    updated_items: Vec<UpdateEntry>,
     buf: Vec<i32>,
+}
+
+#[derive(Clone, Default)]
+struct DeletedItems {
+    by_type: FxHashMap<u16, Vec<u64>>,
+    keys: Vec<i32>,
+}
+
+impl DeletedItems {
+    fn clear(&mut self) {
+        self.by_type.clear();
+        self.keys.clear();
+    }
+    fn len(&self) -> usize {
+        self.keys.len()
+    }
+    fn sort_keys(&mut self) {
+        self.keys.sort_unstable_by_key(|&k| k as u32);
+    }
+    fn insert_key(&mut self, k: i32) -> bool {
+        let raw_type_id = key_to_raw_type_id(k);
+        let id = key_to_id(k);
+        let bits = self.by_type.entry(raw_type_id).or_default();
+        let word = (id as usize) >> 6;
+        if bits.len() <= word {
+            bits.resize(word + 1, 0);
+        }
+        let mask = 1u64 << (id as u32 & 63);
+        let existed = (bits[word] & mask) != 0;
+        if !existed {
+            bits[word] |= mask;
+            self.keys.push(k);
+        }
+        !existed
+    }
+    fn contains_key(&self, k: i32) -> bool {
+        let raw_type_id = key_to_raw_type_id(k);
+        let id = key_to_id(k);
+        let bits = match self.by_type.get(&raw_type_id) {
+            Some(bits) => bits,
+            None => return false,
+        };
+        let word = (id as usize) >> 6;
+        let v = match bits.get(word) {
+            Some(&v) => v,
+            None => return false,
+        };
+        (v & (1u64 << (id as u32 & 63))) != 0
+    }
+}
+
+#[derive(Clone)]
+struct UpdateEntry {
+    key: i32,
+    range: ops::Range<u32>,
+    order: u32,
 }
 
 impl Delta {
@@ -662,42 +937,80 @@ impl Delta {
         self.updated_items.clear();
         self.buf.clear();
     }
-    fn prepare_update_item(&mut self, raw_type_id: u16, id: u16, size: usize) -> &mut [i32] {
-        let key = key(raw_type_id, id);
-
+    fn prepare_update_item(&mut self, key: i32, size: usize, order: u32) -> ops::Range<u32> {
         let offset = self.buf.len();
         let start = offset.assert_u32();
         let end = (offset + size).assert_u32();
-        self.buf.extend(iter::repeat(0).take(size));
-        assert!(self.updated_items.insert(key, start..end).is_none());
-        &mut self.buf[to_usize(start..end)]
+        self.buf.resize(offset + size, 0);
+        let range = start..end;
+        self.updated_items.push(UpdateEntry {
+            key,
+            range: range.clone(),
+            order,
+        });
+        range
     }
     pub fn create(&mut self, from: &Snap, to: &Snap) {
         self.create_raw(&from.raw, &to.raw)
     }
     pub fn create_raw(&mut self, from: &RawSnap, to: &RawSnap) {
         self.clear();
-        for RawItem {
-            raw_type_id, id, ..
-        } in from.items()
-        {
-            if to.item(raw_type_id, id).is_none() {
-                assert!(self.deleted_items.insert(key(raw_type_id, id)));
+        let from_items = &from.items;
+        let to_items = &to.items;
+        let mut index = 0;
+        let mut j = 0;
+
+        self.updated_items.reserve(to_items.len().min(16));
+
+        while index < from_items.len() || j < to_items.len() {
+            let from_key = from_items.get(index).map(|e| e.key);
+            let item_key = to_items.get(j).map(|e| e.key);
+            match (from_key, item_key) {
+                (Some(fk), Some(tk)) => {
+                    if (fk as u32) < (tk as u32) {
+                        assert!(self.deleted_items.insert_key(fk));
+                        index += 1;
+                    } else if (fk as u32) > (tk as u32) {
+                        let data = to.item_from_entry(&to_items[j]);
+                        let range = self.prepare_update_item(tk, data.len(), 0);
+                        let out_delta = &mut self.buf[to_usize(range.clone())];
+                        create_item_delta(None, data, out_delta)
+                            .expect("item sizes can't be mismatched for self-created snapshots");
+                        j += 1;
+                    } else {
+                        let from_data = from.item_from_entry(&from_items[index]);
+                        let to_data = to.item_from_entry(&to_items[j]);
+                        if from_data != to_data {
+                            if from_data.len() == to_data.len() {
+                                let range = self.prepare_update_item(tk, to_data.len(), 0);
+                                let out_delta = &mut self.buf[to_usize(range.clone())];
+                                create_item_delta(Some(from_data), to_data, out_delta)
+                                    .expect("item sizes must match");
+                            } else {
+                                assert!(self.deleted_items.insert_key(fk));
+                                let range = self.prepare_update_item(tk, to_data.len(), 0);
+                                let out_delta = &mut self.buf[to_usize(range.clone())];
+                                out_delta.copy_from_slice(to_data);
+                            }
+                        }
+                        index += 1;
+                        j += 1;
+                    }
+                }
+                (Some(fk), None) => {
+                    assert!(self.deleted_items.insert_key(fk));
+                    index += 1;
+                }
+                (None, Some(tk)) => {
+                    let data = to.item_from_entry(&to_items[j]);
+                    let range = self.prepare_update_item(tk, data.len(), 0);
+                    let out_delta = &mut self.buf[to_usize(range.clone())];
+                    create_item_delta(None, data, out_delta)
+                        .expect("item sizes can't be mismatched for self-created snapshots");
+                    j += 1;
+                }
+                (None, None) => break,
             }
-        }
-        for RawItem {
-            raw_type_id,
-            id,
-            data,
-        } in to.items()
-        {
-            let from_data = from.item(raw_type_id, id);
-            let out_delta = self.prepare_update_item(raw_type_id, id, data.len());
-            create_item_delta(from_data, data, out_delta)
-                .unwrap_or_else(|_| panic!(
-                    "item sizes can't be mismatched for self-created snapshots (raw_type_id={raw_type_id}, id={id})"
-                ));
-            // but they can be different for snapshots received over the network…
         }
     }
 
@@ -715,17 +1028,18 @@ impl Delta {
                 write_int(int)?;
             }
         }
-        for &key in &self.deleted_items {
+        for &key in &self.deleted_items.keys {
             write_int(key)?;
         }
-        for (&key, range) in &self.updated_items {
-            let data = &self.buf[to_usize(range.clone())];
+        for update_entry in &self.updated_items {
+            let key = update_entry.key;
+            let data = &self.buf[to_usize(update_entry.range.clone())];
             let raw_type_id = key_to_raw_type_id(key);
             let id = key_to_id(key);
             write_int(raw_type_id.i32())?;
             write_int(id.i32())?;
             match object_size(raw_type_id) {
-                Some(size) => assert!(size.usize() == data.len()),
+                Some(size) => assert_eq!(size.usize(), data.len()),
                 None => write_int(data.len().assert_i32())?,
             }
             for &d in data {
@@ -754,14 +1068,50 @@ impl Delta {
     where
         O: FnMut(u16) -> Option<u32>,
     {
-        let mut iter = result.iter_mut();
-        self.write_impl(object_size, |int| {
-            *iter.next().ok_or(CapacityError)? = int;
-            Ok(())
-        })?;
-        let remaining = iter.len();
-        let len = result.len() - remaining;
-        Ok(&result[..len])
+        let mut object_size = object_size;
+        let mut idx = 0usize;
+
+        let header = DeltaHeader {
+            num_deleted_items: self.deleted_items.len().assert_i32(),
+            num_updated_items: self.updated_items.len().assert_i32(),
+        };
+        for &int in &header.encode_obj() {
+            *result.get_mut(idx).ok_or(CapacityError)? = int;
+            idx += 1;
+        }
+        for &key in &self.deleted_items.keys {
+            *result.get_mut(idx).ok_or(CapacityError)? = key;
+            idx += 1;
+        }
+        for update_entry in &self.updated_items {
+            let key = update_entry.key;
+            let raw_type_id = key_to_raw_type_id(key);
+            let id = key_to_id(key);
+            *result.get_mut(idx).ok_or(CapacityError)? = raw_type_id.i32();
+            idx += 1;
+            *result.get_mut(idx).ok_or(CapacityError)? = id.i32();
+            idx += 1;
+
+            let data = &self.buf[to_usize(update_entry.range.clone())];
+            match object_size(raw_type_id) {
+                Some(size) => {
+                    assert_eq!(size.usize(), data.len());
+                }
+                None => {
+                    *result.get_mut(idx).ok_or(CapacityError)? = data.len().assert_i32();
+                    idx += 1;
+                }
+            }
+
+            let end = idx + data.len();
+            if end > result.len() {
+                return Err(CapacityError);
+            }
+            result[idx..end].copy_from_slice(data);
+            idx = end;
+        }
+
+        Ok(&result[..idx])
     }
 
     fn read_impl<W, O, R>(&mut self, warn: &mut W, object_size: O, p: &mut R) -> Result<(), Error>
@@ -776,17 +1126,22 @@ impl Delta {
 
         let header = DeltaHeader::decode_impl(warn, p)?;
 
+        let mut dup_delete = false;
         for _ in 0..header.num_deleted_items {
-            self.deleted_items
-                .insert(read_int_err(p, warn, Error::DeletedItemsUnpacking)?);
+            if !self
+                .deleted_items
+                .insert_key(read_int_err(p, warn, Error::DeletedItemsUnpacking)?)
+            {
+                dup_delete = true;
+            }
         }
-        if header.num_deleted_items.assert_usize() != self.deleted_items.len() {
+        if dup_delete {
             warn.warn(Warning::DuplicateDelete);
         }
+        self.deleted_items.sort_keys();
 
-        let mut num_updates = 0;
-
-        while !p.is_empty() {
+        let expected_updates = header.num_updated_items.assert_usize();
+        for order in 0..expected_updates {
             let raw_type_id = read_int_err(p, warn, Error::ItemDiffsUnpacking)?;
             let id = read_int_err(p, warn, Error::ItemDiffsUnpacking)?;
 
@@ -807,24 +1162,38 @@ impl Delta {
                     .push(read_int_err(p, warn, Error::ItemDiffsUnpacking)?);
             }
 
-            // In case of conflict, take later update (as the original code does).
-            if self
-                .updated_items
-                .insert(key(raw_type_id, id), start..end)
-                .is_some()
-            {
-                warn.warn(Warning::DuplicateUpdate);
-            }
+            let key = key(raw_type_id, id);
+            self.updated_items.push(UpdateEntry {
+                key,
+                range: start..end,
+                order: order as u32,
+            });
 
-            if self.deleted_items.contains(&key(raw_type_id, id)) {
+            if self.deleted_items.contains_key(key) {
                 warn.warn(Warning::DeleteUpdate);
             }
-            num_updates += 1;
         }
 
-        if num_updates != header.num_updated_items {
-            warn.warn(Warning::NumUpdatedItems);
+        while !p.is_empty() {
+            if read_int_err(p, warn, Error::ItemDiffsUnpacking)? != 0 {
+                warn.warn(Warning::NumUpdatedItems);
+                break;
+            }
         }
+
+        self.updated_items
+            .sort_unstable_by_key(|u| (u.key as u32, u.order));
+        if self.updated_items.windows(2).any(|w| w[0].key == w[1].key) {
+            warn.warn(Warning::DuplicateUpdate);
+        }
+        self.updated_items.dedup_by(|a, b| {
+            if a.key == b.key {
+                a.clone_from(b);
+                true
+            } else {
+                false
+            }
+        });
 
         Ok(())
     }
@@ -865,13 +1234,67 @@ impl RawBuilder {
         Default::default()
     }
     pub fn add_item(&mut self, type_id: u16, id: u16, data: &[i32]) -> Result<(), BuilderError> {
-        self.snap.add_item(type_id, id, data)
+        let k = key(type_id, id);
+        if !self.snap.seen.insert(k) {
+            return Err(BuilderError::DuplicateKey);
+        }
+        self.snap.push_item_copy(k, data)
     }
     pub fn finish(self) -> RawSnap {
+        let mut snap = self.snap;
+        snap.sort_items();
+        snap
+    }
+
+    /// Finish building a snapshot without sorting items.
+    ///
+    /// This is only valid if items were already added in sorted key order
+    /// (by `(raw_type_id, id)`) and without duplicates.
+    pub fn finish_sorted(self) -> RawSnap {
         self.snap
     }
 }
 
+pub struct RawBuilderSorted {
+    snap: RawSnap,
+    last_key: Option<u32>,
+}
+
+impl Default for RawBuilderSorted {
+    fn default() -> Self {
+        RawBuilderSorted {
+            snap: RawSnap::default(),
+            last_key: None,
+        }
+    }
+}
+
+impl RawBuilderSorted {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Add an item assuming calls come in non-decreasing key order.
+    ///
+    /// This avoids the hash-based duplicate check and allows a `finish_sorted()`
+    /// without any sorting.
+    pub fn add_item(&mut self, type_id: u16, id: u16, data: &[i32]) -> Result<(), BuilderError> {
+        let k = key(type_id, id) as u32;
+        if let Some(prev) = self.last_key {
+            if k <= prev {
+                return Err(BuilderError::DuplicateKey);
+            }
+        }
+        self.last_key = Some(k);
+        self.snap.push_item_copy(k as i32, data)
+    }
+
+    pub fn finish_sorted(self) -> RawSnap {
+        self.snap
+    }
+}
+
+#[derive(Clone)]
 pub struct Builder {
     snap: Snap,
     next_type_id: u16,
@@ -891,49 +1314,83 @@ impl Builder {
         Default::default()
     }
     pub fn add_item(&mut self, type_id: TypeId, id: u16, data: &[i32]) -> Result<(), BuilderError> {
+        // Enforce the item cap BEFORE touching `seen`. push_item (below) rejects over-cap
+        // items, but it runs *after* seen.insert, so rejected keys still accumulate in
+        // SeenKeys; once it fills its 2 * MAX_SNAPSHOT_ITEMS slots, SeenKeys::insert's probe
+        // never finds a free slot and spins forever in release. Reject early so the table
+        // can never overflow. (A laser-heavy snapshot trivially attempts that many keys.)
+        if self.snap.raw.items.len() >= MAX_SNAPSHOT_ITEMS {
+            return Err(BuilderError::TooManyItems);
+        }
         let raw_type_id = match type_id {
             TypeId::Ordinal(ordinal) => {
                 assert!(0 < ordinal && ordinal < OFFSET_EXTENDED_TYPE_ID);
                 ordinal
             }
-            TypeId::Uuid(uuid) => {
-                match self.snap.extended_types.entry(uuid) {
-                    btree_map::Entry::Occupied(o) => *o.get(),
-                    btree_map::Entry::Vacant(v) => {
-                        let raw_type_id = self.next_type_id;
-                        assert!(OFFSET_EXTENDED_TYPE_ID <= raw_type_id, "invalid type ID");
-                        assert!(raw_type_id < 0x8000, "invalid type ID");
-                        self.snap.raw.add_item(
-                            TYPE_ID_EX,
-                            raw_type_id,
-                            &uuid_to_item_data(uuid),
-                        )?;
-                        // Only increment `self.next_type_id` after successful
-                        // insertion.
-                        self.next_type_id += 1;
-                        v.insert(raw_type_id);
-                        raw_type_id
+            TypeId::Uuid(uuid) => match self.snap.extended_types.entry(uuid) {
+                hash_map::Entry::Occupied(o) => *o.get(),
+                hash_map::Entry::Vacant(v) => {
+                    let raw_type_id = self.next_type_id;
+                    assert!(OFFSET_EXTENDED_TYPE_ID <= raw_type_id, "invalid type ID");
+                    assert!(raw_type_id < 0x8000, "invalid type ID");
+                    let ex_key = key(TYPE_ID_EX, raw_type_id);
+                    if !self.snap.raw.seen.insert(ex_key) {
+                        return Err(BuilderError::DuplicateKey);
                     }
+                    self.snap
+                        .raw
+                        .push_item(TYPE_ID_EX, raw_type_id, &uuid_to_item_data(uuid))?;
+                    // Only increment `self.next_type_id` after successful
+                    // insertion.
+                    self.next_type_id += 1;
+                    v.insert(raw_type_id);
+                    raw_type_id
+                }
+            },
+        };
+        if !self.snap.raw.seen.insert(key(raw_type_id, id)) {
+            return Err(BuilderError::DuplicateKey);
+        }
+        self.snap.raw.push_item(raw_type_id, id, data)
+    }
+
+    pub fn register_uuid(&mut self, uuid: Uuid) {
+        match self.snap.extended_types.entry(uuid) {
+            hash_map::Entry::Occupied(_) => {}
+            hash_map::Entry::Vacant(v) => {
+                let raw_type_id = self.next_type_id;
+                assert!(OFFSET_EXTENDED_TYPE_ID <= raw_type_id, "invalid type ID");
+                assert!(raw_type_id < 0x8000, "invalid type ID");
+                let ex_key = key(TYPE_ID_EX, raw_type_id);
+                if self.snap.raw.seen.insert(ex_key) {
+                    self.snap
+                        .raw
+                        .push_item(TYPE_ID_EX, raw_type_id, &uuid_to_item_data(uuid))
+                        .expect("failed to add UUID item to snapshot");
+                    self.next_type_id += 1;
+                    v.insert(raw_type_id);
                 }
             }
-        };
-        self.snap.raw.add_item(raw_type_id, id, data)
+        }
     }
+
     pub fn finish(self) -> Snap {
-        self.snap
+        let mut snap = self.snap;
+        snap.raw.sort_items();
+        snap
     }
 }
 
 pub fn delta_chunks(tick: i32, delta_tick: i32, data: &[u8], crc: i32) -> DeltaChunks<'_> {
     DeltaChunks {
-        tick: tick,
+        tick,
         delta_tick: tick - delta_tick,
-        crc: crc,
+        crc,
         cur_part: if !data.is_empty() { 0 } else { -1 },
         num_parts: ((data.len() + MAX_SNAPSHOT_PACKSIZE as usize - 1)
             / MAX_SNAPSHOT_PACKSIZE as usize)
             .assert_i32(),
-        data: data,
+        data,
     }
 }
 

--- a/snapshot/src/storage.rs
+++ b/snapshot/src/storage.rs
@@ -68,8 +68,7 @@ impl Storage {
     }
     pub fn reset(&mut self) {
         let self_free = &mut self.free;
-        // FIXME: Replace with something like `exhaust`.
-        self.snaps.drain(..).map(|s| self_free.push(s.snap)).count();
+        self_free.extend(self.snaps.drain(..).map(|s| s.snap));
         self.ack_tick = None;
     }
     pub fn ack_tick(&self) -> Option<i32> {
@@ -95,11 +94,7 @@ impl Storage {
             if delta_tick >= 0 {
                 if let Some(i) = self.snaps.iter().position(|s| s.tick < delta_tick) {
                     let self_free = &mut self.free;
-                    // FIXME: Replace with something like `exhaust`.
-                    self.snaps
-                        .drain(i..)
-                        .map(|s| self_free.push(s.snap))
-                        .count();
+                    self_free.extend(self.snaps.drain(i..).map(|s| s.snap));
                 }
                 if let Some(d) = self.snaps.back() {
                     if d.tick == delta_tick {
@@ -155,11 +150,7 @@ impl Storage {
         }
         if let Some(i) = self.snaps.iter().position(|s| s.tick < tick) {
             let self_free = &mut self.free;
-            // FIXME: Replace with something like `exhaust`.
-            self.snaps
-                .drain(i..)
-                .map(|s| self_free.push(s.snap))
-                .count();
+            self_free.extend(self.snaps.drain(i..).map(|s| s.snap));
         }
         if !self.snaps.back().map(|s| s.tick == tick).unwrap_or(false) {
             self.delta_tick = None;


### PR DESCRIPTION
My goal is to fix 
https://github.com/ddnet/ddnet/issues/12075#issuecomment-4825250926

All changes are made for optimization/bug fixes and have been tested on 0XF(0.6 only).
I am asking that this be given a high priority for review now.

bench:
- comit: https://github.com/heinrich5991/libtw2/commit/9ef70df5b845faf6872e2d71971b7b96ed0a5c1b
```
running 20 tests
test delta_300_300_libtw2            ... bench:      49,919 ns/iter (+/- 6,641)
test delta_300_300_reference         ... bench:      13,753 ns/iter (+/- 1,108)
test delta_300_300m_libtw2           ... bench:      49,206 ns/iter (+/- 5,625)
test delta_300_300m_reference        ... bench:      14,049 ns/iter (+/- 2,007)
test delta_empty_empty_libtw2        ... bench:          23 ns/iter (+/- 6)
test delta_empty_empty_reference     ... bench:         233 ns/iter (+/- 128)
test snap_300_libtw2                 ... bench:      21,848 ns/iter (+/- 2,112)
test snap_300_reference              ... bench:       5,656 ns/iter (+/- 554)
test snap_empty_libtw2               ... bench:          32 ns/iter (+/- 2)
test snap_empty_reference            ... bench:          35 ns/iter (+/- 6)
test snapdelta_300_300_libtw2        ... bench:      83,817 ns/iter (+/- 9,528)
test snapdelta_300_300_reference     ... bench:      19,117 ns/iter (+/- 4,004)
test snapdelta_300_300m_libtw2       ... bench:      83,840 ns/iter (+/- 8,127)
test snapdelta_300_300m_reference    ... bench:      19,324 ns/iter (+/- 2,907)
test snapdelta_empty_empty_libtw2    ... bench:          51 ns/iter (+/- 5)
test snapdelta_empty_empty_reference ... bench:         271 ns/iter (+/- 20)
test snapwrite_300_libtw2            ... bench:      52,492 ns/iter (+/- 2,664)
test snapwrite_300_reference         ... bench:       5,885 ns/iter (+/- 892)
test snapwrite_empty_libtw2          ... bench:          46 ns/iter (+/- 5)
test snapwrite_empty_reference       ... bench:          41 ns/iter (+/- 4)
```

- This version
```
running 20 tests
test delta_300_300_libtw2            ... bench:       2,741 ns/iter (+/- 266)
test delta_300_300_reference         ... bench:      13,259 ns/iter (+/- 993)
test delta_300_300m_libtw2           ... bench:       3,331 ns/iter (+/- 337)
test delta_300_300m_reference        ... bench:      13,960 ns/iter (+/- 1,566)
test delta_empty_empty_libtw2        ... bench:          10 ns/iter (+/- 2)
test delta_empty_empty_reference     ... bench:         227 ns/iter (+/- 12)
test snap_300_libtw2                 ... bench:       5,902 ns/iter (+/- 497)
test snap_300_reference              ... bench:       5,230 ns/iter (+/- 1,445)
test snap_empty_libtw2               ... bench:          36 ns/iter (+/- 3)
test snap_empty_reference            ... bench:          34 ns/iter (+/- 4)
test snapdelta_300_300_libtw2        ... bench:       8,914 ns/iter (+/- 1,207)
test snapdelta_300_300_reference     ... bench:      18,938 ns/iter (+/- 1,207)
test snapdelta_300_300m_libtw2       ... bench:       9,409 ns/iter (+/- 783)
test snapdelta_300_300m_reference    ... bench:      19,289 ns/iter (+/- 4,446)
test snapdelta_empty_empty_libtw2    ... bench:          44 ns/iter (+/- 5)
test snapdelta_empty_empty_reference ... bench:         271 ns/iter (+/- 21)
test snapwrite_300_libtw2            ... bench:       7,780 ns/iter (+/- 557)
test snapwrite_300_reference         ... bench:       5,563 ns/iter (+/- 576)
test snapwrite_empty_libtw2          ... bench:          40 ns/iter (+/- 13)
test snapwrite_empty_reference       ... bench:          39 ns/iter (+/- 4)
```

These changes were created about a month ago and were corrected up to the current moment in 0XF.